### PR TITLE
Add a test for (and work around) an "infer mport"

### DIFF
--- a/src/main/stanza/compilers.stanza
+++ b/src/main/stanza/compilers.stanza
@@ -74,9 +74,9 @@ public defmethod passes (c:StandardVerilog) -> List<Pass> :
       ;RemoveSpecialChars()     
       ;TempElimination()                 ; Needs to check number of uses
       ;===============
-      ;CInferTypes()
-      ;CInferMDir()
-      ;RemoveCHIRRTL()            
+      CInferTypes()
+      CInferMDir()
+      RemoveCHIRRTL()            
       ;===============
       ToWorkingIR()            
       ;===============


### PR DESCRIPTION
This also contains a workaround that Adam suggested.  I don't think it should
be merged, I'm PRing this for the test case.