### PR TITLE
Fixed printf bugs in scala and stanza versions

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -362,21 +362,8 @@ object VerilogEmitter extends Emitter {
          Seq("$fdisplay(32'h80000002,\"",ret,"\");$finish;")
       }
       def printf (str:String,args:Seq[Expression]) : Seq[Any] = {
-         def emitArg(exp: Expression): String = {
-            exp match {
-               case v: UIntValue => s"${v.width match {
-                  case w: IntWidth => w.width.toString
-               }}'H${v.value.toString(16)}"
-               case v: SIntValue => s"${v.width match {
-                  case w: IntWidth => w.width.toString
-               }}'sH${v.value.toString(16)}"
-               case r: Ref => r.name
-               case r: WRef => r.name
-               case _ => error("Unexpected expression in printf: " + exp.serialize)
-            }
-         }
          val q = '"'.toString
-         val strx = (Seq(q + escape(str) + q) ++ args.map(x => emitArg(x))).reduce(_ + "," + _)
+	 val strx = (Seq(q + escape(str) + q) ++ args.flatMap(x => Seq(",",x)))
          Seq("$fwrite(32'h80000002,",strx,");")
       }
       def delay (e:Expression, n:Int, clk:Expression) : Expression = {

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -1252,9 +1252,16 @@ object SplitExp extends Pass {
                case (e) => e
             }
          }
-         eMap(split_exp_e(0) _,s) match {
+	 s match {
             case (s:Begin) => sMap(split_exp_s _,s)
-            case (s) => v += s; s
+	    case (s:Print) => {
+		val sx = eMap(split_exp_e(1) _,s)
+                v += sx; sx
+	    }
+            case (s) => {
+		val sx = eMap(split_exp_e(0) _,s)
+                v += sx; sx
+	    }
          }
       }
       split_exp_s(m.body)

--- a/src/main/stanza/passes.stanza
+++ b/src/main/stanza/passes.stanza
@@ -1844,11 +1844,16 @@ defn split-exp (m:InModule) -> InModule :
                if i > 0 : split(e)
                else : e
             (e) : e
-      match(map(split-exp-e{_,0},s)) :
+      match(s) :
          (s:Begin) : map(split-exp-s,s)
-         (s) : 
-            add(v,s)
-            s
+         (s:Print) :
+            val s* = map(split-exp-e{_,1},s)
+            add(v,s*)
+            s*
+         (s) :
+            val s* = map(split-exp-e{_,0},s)
+            add(v,s*)
+            s*
    split-exp-s(body(m))
    InModule(info(m),name(m),ports(m),Begin(to-list(v)))
 
@@ -2696,7 +2701,7 @@ defn emit-verilog (m:InModule) -> Module :
    defn stop (ret:Int) -> Streamable :
       ["$fdisplay(32'h80000002,\"" ret "\");$finish;"]
    defn printf (str:String,args:List<Expression>) -> Streamable :
-      val str* = join(List(escape(str),map(escape,map(to-string,args))),",")
+      val str* = join(List(escape(str),args),",")
       ["$fwrite(32'h80000002," str* ");"]
    defn delay (e:Expression, n:Int, clk:Expression) -> Expression :
       var e* = e

--- a/src/test/scala/firrtlTests/Regress.scala
+++ b/src/test/scala/firrtlTests/Regress.scala
@@ -18,6 +18,8 @@ class RocketRegressionSpec extends FlatSpec with Matchers {
 
     val goldenVerilog = Source.fromURL(getClass.getResource("/regress/rocket-golden.v"))
     
-    verilogSW.toString shouldEqual goldenVerilog.mkString 
+    verilogSW.toString.split("\n") zip goldenVerilog.getLines.toSeq foreach {
+      case (verilog, golden) => verilog shouldEqual golden
+    }
   }
 }

--- a/test/passes/split-exp/print-args.fir
+++ b/test/passes/split-exp/print-args.fir
@@ -1,0 +1,14 @@
+; RUN: firrtl -i %s -o %s.v -X verilog -p c 2>&1 | tee %s.out | FileCheck %s
+
+; CHECK: Split Expressions
+; CHECK: node GEN_0 = and(a, b)
+; CHECK: printf(clk, UInt<1>("h1"), "%d\n", GEN_0)
+
+circuit Bug :
+  module Bug :
+    input clk : Clock
+    input a : UInt<1>
+    input b : UInt<1>
+
+    printf(clk, UInt<1>(1), "%d\n", and(a, b))
+

--- a/test/passes/to-verilog/print-args.fir
+++ b/test/passes/to-verilog/print-args.fir
@@ -1,0 +1,25 @@
+; RUN: firrtl -i %s -o %s.v -X verilog ; cat %s.v | FileCheck %s
+
+;CHECK: module Bug(
+;CHECK:    input   clk,
+;CHECK:    input   a,
+;CHECK:    input   b
+;CHECK: );
+;CHECK:    wire  GEN_0;
+;CHECK:    assign GEN_0 = a & b;
+;CHECK:    always @(posedge clk) begin
+;CHECK:       `ifndef SYNTHESIS
+;CHECK:          if(1'h1) begin
+;CHECK:             $fwrite(32'h80000002,"%d\n",GEN_0);
+;CHECK:          end
+;CHECK:       `endif
+;CHECK:    end
+;CHECK: endmodule
+
+circuit Bug :
+  module Bug :
+    input clk : Clock
+    input a : UInt<1>
+    input b : UInt<1>
+
+    printf(clk, UInt<1>(1), "%d\n", and(a, b))


### PR DESCRIPTION
Required special casing prints in SplitExp, and emitting expressions instead of their toString counterparts