### PR TITLE
Remove implicits from serialize

### DIFF
--- a/src/main/scala/firrtl/IR.scala
+++ b/src/main/scala/firrtl/IR.scala
@@ -44,7 +44,9 @@ case class FileInfo(file: String, line: Int, column: Int) extends Info {
 
 case class FIRRTLException(str:String) extends Exception
 
-trait AST 
+trait AST {
+  def serialize: String = firrtl.Serialize.serialize(this)
+}
 
 trait PrimOp extends AST
 case object ADD_OP extends PrimOp 

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -697,7 +697,7 @@ object CheckWidths extends Pass with StanzaPass {
                   (e.width) match { 
                      case (w:IntWidth) => 
                         if (scala.math.max(1,e.value.bitLength) > w.width) {
-                           errors += new WidthTooSmall(info,e.value.serialize)
+                           errors += new WidthTooSmall(info, serialize(e.value))
                         }
                      case (w) => errors += new UninferredWidth(info)
                   }
@@ -706,7 +706,7 @@ object CheckWidths extends Pass with StanzaPass {
                case (e:SIntValue) => {
                   (e.width) match { 
                      case (w:IntWidth) => 
-                        if (e.value.bitLength + 1 > w.width) errors += new WidthTooSmall(info,e.value.serialize)
+                        if (e.value.bitLength + 1 > w.width) errors += new WidthTooSmall(info, serialize(e.value))
                      case (w) => errors += new UninferredWidth(info)
                   }
                   check_width_w(info)(e.width)


### PR DESCRIPTION
implicits should be avoided, rather, a single function on AST can call serialize functions for all FIRRTL graph nodes. 

These serialize functions could be migrated to the actual traits and case classes in IR.scala. I originally didn't put them there in order to keep the IR "self documenting", but perhaps that's just better handled by the FIRRTL Spec and ScalaDocs. 