### PR TITLE
Fix inferred width on SInts

### DIFF
--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -245,7 +245,7 @@ class Visitor(val fullFilename: String) extends FIRRTLBaseVisitor[AST]
               (IntWidth(string2BigInt(ctx.IntLit(0).getText)), string2BigInt(ctx.IntLit(1).getText))
             else {
                val bigint = string2BigInt(ctx.IntLit(0).getText)
-               (IntWidth(BigInt(bigint.bitLength + 1)),bigint)
+               (IntWidth(BigInt(scala.math.max(bigint.bitLength,1))),bigint)
             }
           SIntValue(value, width)
         }

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -707,7 +707,7 @@ object CheckWidths extends Pass with StanzaPass {
                case (e:SIntValue) => {
                   (e.width) match { 
                      case (w:IntWidth) => 
-                        if (e.value.bitLength + 1 > w.width) errors += new WidthTooSmall(info, serialize(e.value))
+                        if (e.value.bitLength > w.width) errors += new WidthTooSmall(info, serialize(e.value))
                      case (w) => errors += new UninferredWidth(info)
                   }
                   check_width_w(info)(e.width)

--- a/test/features/SIntWidth.fir
+++ b/test/features/SIntWidth.fir
@@ -1,0 +1,8 @@
+; RUN: firrtl -i %s -o %s.v -X verilog -p cd 2>&1 | tee %s.out; cat %s.v | FileCheck %s
+
+circuit Top :
+  module Top :
+    input reset : UInt<1>
+    node a = SInt("hF")
+
+;CHECK: assign a = 4'shf;


### PR DESCRIPTION
SInts were given a width one larger than desired. This fixes it.