### PR TITLE
Fixed bug in recursive check for whether BundleType contains flips.

### DIFF
--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -96,7 +96,7 @@ object CheckHighForm extends Pass with LazyLogging {
   def hasFlip(t: Type): Boolean = {
     var has = false
     def findFlip(t: Type): Type = {
-      t match {
+      t map (findFlip) match {
         case t: BundleType => {
           for (f <- t.fields) {
             if (f.flip == REVERSE) has = true
@@ -107,7 +107,6 @@ object CheckHighForm extends Pass with LazyLogging {
       }
     }
     findFlip(t)
-    t map (findFlip)
     has
   }
 

--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -1,0 +1,28 @@
+package firrtlTests
+
+import java.io._
+import org.scalatest._
+import org.scalatest.prop._
+import firrtl.{Parser,Circuit}
+import firrtl.passes.{Pass,ToWorkingIR,CheckHighForm,ResolveKinds,InferTypes,CheckTypes,PassExceptions}
+
+class CheckSpec extends FlatSpec with Matchers {
+  "Connecting bundles of different types" should "throw an exception" in {
+    val passes = Seq(
+      ToWorkingIR,
+      CheckHighForm)
+    val input =
+      """circuit Unit :
+        |  module Unit :
+        |    mem m :
+        |      data-type => {a : {b : {flip c : UInt<32>}}}
+        |      depth => 32
+        |      read-latency => 0
+        |      write-latency => 1""".stripMargin
+    intercept[PassExceptions] {
+      passes.foldLeft(Parser.parse("",input.split("\n").toIterator)) {
+        (c: Circuit, p: Pass) => p.run(c)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Before, only the bundle and all its children were checked for flips. Now, all children types, recursively, are checked.