### PR TITLE
Add Expression.tpe accessor

### DIFF
--- a/src/main/scala/firrtl/IR.scala
+++ b/src/main/scala/firrtl/IR.scala
@@ -89,15 +89,21 @@ case object BITS_SELECT_OP extends PrimOp
 case object HEAD_OP extends PrimOp
 case object TAIL_OP extends PrimOp
 
-trait Expression extends AST
+trait Expression extends AST {
+  def tpe: Type
+}
 case class Ref(name: String, tpe: Type) extends Expression with HasName
 case class SubField(exp: Expression, name: String, tpe: Type) extends Expression with HasName
 case class SubIndex(exp: Expression, value: Int, tpe: Type) extends Expression
 case class SubAccess(exp: Expression, index: Expression, tpe: Type) extends Expression
 case class Mux(cond: Expression, tval: Expression, fval: Expression, tpe: Type) extends Expression
 case class ValidIf(cond: Expression, value: Expression, tpe: Type) extends Expression
-case class UIntValue(value: BigInt, width: Width) extends Expression
-case class SIntValue(value: BigInt, width: Width) extends Expression
+case class UIntValue(value: BigInt, width: Width) extends Expression {
+  def tpe = UIntType(width)
+}
+case class SIntValue(value: BigInt, width: Width) extends Expression {
+  def tpe = SIntType(width)
+}
 case class DoPrim(op: PrimOp, args: Seq[Expression], consts: Seq[BigInt], tpe: Type) extends Expression
 
 trait Stmt extends AST

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -53,8 +53,8 @@ case class WRef(name:String,tpe:Type,kind:Kind,gender:Gender) extends Expression
 case class WSubField(exp:Expression,name:String,tpe:Type,gender:Gender) extends Expression
 case class WSubIndex(exp:Expression,value:Int,tpe:Type,gender:Gender) extends Expression
 case class WSubAccess(exp:Expression,index:Expression,tpe:Type,gender:Gender) extends Expression
-case class WVoid() extends Expression
-case class WInvalid() extends Expression
+case class WVoid() extends Expression { def tpe = UnknownType() }
+case class WInvalid() extends Expression { def tpe = UnknownType() }
 case class WDefInstance(info:Info,name:String,module:String,tpe:Type) extends Stmt 
 
 case object ADDW_OP extends PrimOp 


### PR DESCRIPTION
Almost all of the code was already there.  This is cleaner (and faster)
than calling tpe(Expression).