### PR TITLE
Add namespace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,4 +36,3 @@ antlr4GenListener in Antlr4 := false // default = true
 
 antlr4PackageName in Antlr4 := Option("firrtl.antlr")
 
-parallelExecution in Test := false

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -256,11 +256,12 @@ class VerilogEmitter extends Emitter {
       mname = m.name
       val netlist = LinkedHashMap[WrappedExpression,Expression]()
       val simlist = ArrayBuffer[Stmt]()
+      val namespace = Namespace(m)
       def build_netlist (s:Stmt) : Stmt = {
          s match {
             case (s:Connect) => netlist(s.loc) = s.exp
             case (s:IsInvalid) => {
-               val n = firrtl_gensym_module(mname)
+               val n = namespace.newTemp
                val e = wref(n,tpe(s.exp))
                netlist(s.exp) = e
             }
@@ -372,7 +373,7 @@ class VerilogEmitter extends Emitter {
       def delay (e:Expression, n:Int, clk:Expression) : Expression = {
          var ex = e
          for (i <- 0 until n) {
-            val name = firrtl_gensym_module(mname)
+            val name = namespace.newTemp
             declare("reg",name,tpe(e))
             val exx = WRef(name,tpe(e),ExpKind(),UNKNOWNGENDER)
             update(exx,ex,clk,one)

--- a/src/main/scala/firrtl/IR.scala
+++ b/src/main/scala/firrtl/IR.scala
@@ -48,6 +48,11 @@ trait AST {
   def serialize: String = firrtl.Serialize.serialize(this)
 }
 
+trait HasName {
+  val name: String
+}
+trait IsDeclaration extends HasName
+
 case class StringLit(array: Array[Byte]) extends AST
 
 trait PrimOp extends AST
@@ -85,8 +90,8 @@ case object HEAD_OP extends PrimOp
 case object TAIL_OP extends PrimOp
 
 trait Expression extends AST
-case class Ref(name: String, tpe: Type) extends Expression
-case class SubField(exp: Expression, name: String, tpe: Type) extends Expression
+case class Ref(name: String, tpe: Type) extends Expression with HasName
+case class SubField(exp: Expression, name: String, tpe: Type) extends Expression with HasName
 case class SubIndex(exp: Expression, value: Int, tpe: Type) extends Expression
 case class SubAccess(exp: Expression, index: Expression, tpe: Type) extends Expression
 case class Mux(cond: Expression, tval: Expression, fval: Expression, tpe: Type) extends Expression
@@ -96,13 +101,13 @@ case class SIntValue(value: BigInt, width: Width) extends Expression
 case class DoPrim(op: PrimOp, args: Seq[Expression], consts: Seq[BigInt], tpe: Type) extends Expression
 
 trait Stmt extends AST
-case class DefWire(info: Info, name: String, tpe: Type) extends Stmt
-case class DefPoison(info: Info, name: String, tpe: Type) extends Stmt
-case class DefRegister(info: Info, name: String, tpe: Type, clock: Expression, reset: Expression, init: Expression) extends Stmt 
-case class DefInstance(info: Info, name: String, module: String) extends Stmt 
+case class DefWire(info: Info, name: String, tpe: Type) extends Stmt with IsDeclaration
+case class DefPoison(info: Info, name: String, tpe: Type) extends Stmt with IsDeclaration
+case class DefRegister(info: Info, name: String, tpe: Type, clock: Expression, reset: Expression, init: Expression) extends Stmt with IsDeclaration
+case class DefInstance(info: Info, name: String, module: String) extends Stmt with IsDeclaration
 case class DefMemory(info: Info, name: String, data_type: Type, depth: Int, write_latency: Int, 
-               read_latency: Int, readers: Seq[String], writers: Seq[String], readwriters: Seq[String]) extends Stmt
-case class DefNode(info: Info, name: String, value: Expression) extends Stmt
+               read_latency: Int, readers: Seq[String], writers: Seq[String], readwriters: Seq[String]) extends Stmt with IsDeclaration
+case class DefNode(info: Info, name: String, value: Expression) extends Stmt with IsDeclaration
 case class Conditionally(info: Info, pred: Expression, conseq: Stmt, alt: Stmt) extends Stmt
 case class Begin(stmts: Seq[Stmt]) extends Stmt
 case class BulkConnect(info: Info, loc: Expression, exp: Expression) extends Stmt
@@ -137,7 +142,7 @@ trait Flip extends AST
 case object DEFAULT extends Flip
 case object REVERSE extends Flip
 
-case class Field(name: String, flip: Flip, tpe: Type) extends AST
+case class Field(name: String, flip: Flip, tpe: Type) extends AST with IsDeclaration // ?
 
 trait Type extends AST
 case class UIntType(width: Width) extends Type
@@ -151,9 +156,9 @@ trait Direction extends AST
 case object INPUT extends Direction
 case object OUTPUT extends Direction
 
-case class Port(info: Info, name: String, direction: Direction, tpe: Type) extends AST
+case class Port(info: Info, name: String, direction: Direction, tpe: Type) extends AST with IsDeclaration
 
-trait Module extends AST {
+trait Module extends AST with IsDeclaration {
   val info : Info
   val name : String
   val ports : Seq[Port]

--- a/src/main/scala/firrtl/Namespace.scala
+++ b/src/main/scala/firrtl/Namespace.scala
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2014 - 2016 The Regents of the University of
+California (Regents). All Rights Reserved.  Redistribution and use in
+source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+   * Redistributions of source code must retain the above
+     copyright notice, this list of conditions and the following
+     two paragraphs of disclaimer.
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     two paragraphs of disclaimer in the documentation and/or other materials
+     provided with the distribution.
+   * Neither the name of the Regents nor the names of its contributors
+     may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+*/
+
+package firrtl
+
+import scala.collection.mutable.HashSet
+import Mappers._
+
+class Namespace private {
+  private val tempNamePrefix: String = "GEN"
+  // Begin with a tempNamePrefix in namespace so we always have a number suffix
+  private val namespace = HashSet[String](tempNamePrefix)
+  private var n = 0L
+
+  def tryName(value: String): Boolean = {
+    if (!namespace.contains(value)) {
+      namespace += value
+      true
+    } else {
+      false
+    }
+  }
+  def newName(value: String): String = {
+    var str = value
+    while (!tryName(str)) {
+      str = s"${value}_$n"
+      n += 1
+    }
+    str
+  }
+  def newTemp: String = newName(tempNamePrefix)
+}
+
+object Namespace {
+  def apply(): Namespace = new Namespace
+
+  // Initializes a namespace from a Module
+  def apply(m: Module): Namespace = {
+    val namespace = new Namespace
+
+    def buildNamespaceStmt(s: Stmt): Stmt =
+      s map buildNamespaceStmt match {
+        case dec: IsDeclaration =>
+          namespace.namespace += dec.name
+          dec
+        case x => x
+      }
+    def buildNamespacePort(p: Port): Port = p match {
+      case dec: IsDeclaration =>
+        namespace.namespace += dec.name
+        dec
+      case x => x
+    }
+    m.ports map buildNamespacePort
+    m match {
+      case in: InModule => buildNamespaceStmt(in.body)
+      case _ => // Do nothing
+    }
+
+    namespace
+  }
+}
+

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -61,7 +61,6 @@ object Utils {
    def ceil_log2(x: Int): Int = scala.math.ceil(scala.math.log(x) / scala.math.log(2)).toInt
    val gen_names = Map[String,Int]()
    val delin = "_"
-   val sym_hash = LinkedHashMap[String,LinkedHashMap[String,Int]]()
    def BoolType () = { UIntType(IntWidth(1)) } 
    val one  = UIntValue(BigInt(1),IntWidth(1))
    val zero = UIntValue(BigInt(0),IntWidth(1))
@@ -73,24 +72,6 @@ object Utils {
    def req_num_bits (i: Int) : Int = {
       val ix = if (i < 0) ((-1 * i) - 1) else i
       ceil_log2(ix + 1) + 1
-   }
-   def firrtl_gensym (s:String):String = { firrtl_gensym(s,LinkedHashMap[String,Int]()) }
-   def firrtl_gensym (sym_hash:LinkedHashMap[String,Int]):String = { firrtl_gensym("GEN",sym_hash) }
-   def firrtl_gensym_module (s:String):String = {
-      val sh = sym_hash.getOrElse(s,LinkedHashMap[String,Int]())
-      val name = firrtl_gensym("GEN",sh)
-      sym_hash(s) = sh
-      name
-   }
-   def firrtl_gensym (s:String,sym_hash:LinkedHashMap[String,Int]):String = {
-      if (sym_hash contains s) {
-         val num = sym_hash(s) + 1
-         sym_hash += (s -> num)
-         (s + delin + num)
-      } else {
-         sym_hash += (s -> 0)
-         (s + delin + 0)
-      }
    }
    def AND (e1:WrappedExpression,e2:WrappedExpression) : Expression = {
       if (e1 == e2) e1.e1


### PR DESCRIPTION
Replace gensym with Namespace

Most replacing was trivial, InferTypes required a little bit of massaging because of its use of public utility function

IsDeclaration trait is a useful thing to match on as shown in Namespace.scala, but are Fields declarations? They are if you want to create the namespace for a bundle.

I put Namespace in its own file as opposed to Utils because the next step is to replace all names with Identifier wrappers and that will need to be in a separate file with Namespace