### PR TITLE
Fix bundle equality check

### DIFF
--- a/src/main/scala/firrtl/Parser.scala
+++ b/src/main/scala/firrtl/Parser.scala
@@ -48,7 +48,7 @@ object Parser extends LazyLogging
     *
     * Parser performs conversion to machine firrtl
     */
-  def parse(filename: String, lines: Iterator[String]): Circuit = {
+  def parse(filename: String, lines: Iterator[String], useInfo: Boolean = true): Circuit = {
     val fixedInput = Translator.addBrackets(lines)
     //logger.debug("Preprocessed Input:\n" + fixedInput.result) 
     val antlrStream = new ANTLRInputStream(fixedInput.result)
@@ -65,7 +65,7 @@ object Parser extends LazyLogging
     val numSyntaxErrors = parser.getNumberOfSyntaxErrors
     if (numSyntaxErrors > 0) throw new ParserException(s"${numSyntaxErrors} syntax error(s) detected")
 
-    val visitor = new Visitor(filename) 
+    val visitor = new Visitor(filename, useInfo) 
     //val ast = visitor.visitCircuit(cst) match {
     val ast = visitor.visit(cst) match {
       case c: Circuit => c

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -43,7 +43,7 @@ import PrimOps._
 import FIRRTLParser._
 import scala.annotation.tailrec
 
-class Visitor(val fullFilename: String) extends FIRRTLBaseVisitor[AST] 
+class Visitor(val fullFilename: String, val useInfo : Boolean) extends FIRRTLBaseVisitor[AST] 
 {
   // Strip file path
   private val filename = fullFilename.drop(fullFilename.lastIndexOf("/")+1)
@@ -78,7 +78,9 @@ class Visitor(val fullFilename: String) extends FIRRTLBaseVisitor[AST]
   }
   private def string2Int(s: String): Int = string2BigInt(s).toInt
   private def getInfo(ctx: ParserRuleContext): Info = 
-    FileInfo(filename, ctx.getStart().getLine(), ctx.getStart().getCharPositionInLine())
+    if (useInfo) {
+      FileInfo(filename, ctx.getStart().getLine(), ctx.getStart().getCharPositionInLine())
+    } else NoInfo
 
 	private def visitCircuit[AST](ctx: FIRRTLParser.CircuitContext): Circuit = 
     Circuit(getInfo(ctx), ctx.module.map(visitModule), (ctx.id.getText)) 


### PR DESCRIPTION
The partial connect operator can now legally connect the types:
`{a: {flip b: UInt<3>}}`
 and 
`{flip a: {b: UInt<3>}}`