### PR TITLE
Improve chisel assert

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -83,11 +83,11 @@ object VerilogCompiler extends Compiler {
     InferTypes,
     ResolveGenders,
     InferWidths,
+    SplitExp,
     ConstProp,
     CommonSubexpressionElimination,
     DeadCodeElimination,
     VerilogWrap,
-    SplitExp,
     VerilogRename
   )
   def run(c: Circuit, w: Writer)

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -1244,16 +1244,16 @@ object SplitExp extends Pass {
                case (e) => e
             }
          }
-	 s match {
+         s match {
             case (s:Begin) => s map (split_exp_s)
-	    case (s:Print) => {
-		val sx = s map (split_exp_e(1))
-                v += sx; sx
-	    }
+            case (s:Print) => {
+               val sx = s map (split_exp_e(1))
+               v += sx; sx
+            }
             case (s) => {
-		val sx = s map (split_exp_e(0))
-                v += sx; sx
-	    }
+               val sx = s map (split_exp_e(0))
+               v += sx; sx
+            }
          }
       }
       split_exp_s(m.body)

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -1250,6 +1250,10 @@ object SplitExp extends Pass {
                val sx = s map (split_exp_e(1))
                v += sx; sx
             }
+            case (s:Stop) => {
+               val sx = s map (split_exp_e(1))
+               v += sx; sx
+            }
             case (s) => {
                val sx = s map (split_exp_e(0))
                v += sx; sx


### PR DESCRIPTION
I got sick of the printf and stop resulting from Chisel asserts being guarded separately, so by moving SplitExp to before ConstProp, CSE, and DCE, and by making sure expressions are split out of Stops, we get my desired result:

```
circuit Assert :
  module Assert :
    input clk : Clock
    input reset : UInt<1>

    reg foo : UInt<16>, clk with : (reset => (reset, UInt(0)))
    foo <= add(foo, UInt(1))

    when not(reset) :
      when eq(foo, UInt(13)) :
        printf(clk, UInt(1), "Assertion failed!\n")
        stop(clk, UInt(1), 1)
```

Will now lower to:

```
 circuit Assert : 
  module Assert : 
    input clk : Clock
    input reset : UInt<1>
    reg foo : UInt<16>, clk with : 
      reset => (reset, UInt<1>("h0"))
    node GEN_0 = not(reset)
    node GEN_1 = eq(foo, UInt<4>("hd"))
    node GEN_2 = and(GEN_0, GEN_1)
    printf(clk, GEN_2, "Assertion failed!\n")
    stop(clk, GEN_2, 1)
    foo <= add(foo, UInt<1>("h1"))
```