### PR TITLE
Fix rwmem

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -554,7 +554,13 @@ class VerilogEmitter extends Emitter {
                   val rmem_port = WSubAccess(mem,raddrx,s.data_type,UNKNOWNGENDER)
                   assign(rdata,rmem_port)
                   val wmem_port = WSubAccess(mem,waddrx,s.data_type,UNKNOWNGENDER)
-                  update(wmem_port,datax,clk,AND(AND(enx,maskx),wmode))
+
+                  val tempName = namespace.newTemp
+                  val tempExp = AND(enx,maskx)
+                  declare("wire", tempName, tpe(tempExp))
+                  val tempWRef = wref(tempName, tpe(tempExp))
+                  assign(tempWRef, tempExp)
+                  update(wmem_port,datax,clk,AND(tempWRef,wmode))
                }
             }
             case (s:Begin) => s map (build_streams)

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -100,7 +100,7 @@ object LowerTypes extends Pass {
       def lowerTypesMemExp(e: Expression): Seq[Expression] = {
         val (mem, port, field, tail) = splitMemRef(e)
         // Fields that need to be replicated for each resulting mem
-        if (Seq("addr", "en", "clk", "rmode").contains(field.name)) {
+        if (Seq("addr", "en", "clk", "wmode").contains(field.name)) {
           require(tail.isEmpty) // there can't be a tail for these
           val memType = memDataTypeMap(mem.name)
 

--- a/src/test/scala/firrtlTests/IntegrationSpec.scala
+++ b/src/test/scala/firrtlTests/IntegrationSpec.scala
@@ -35,7 +35,8 @@ class IntegrationSpec extends FirrtlPropSpec {
   case class Test(name: String, dir: String)
 
   val runTests = Seq(Test("GCDTester", "/integration"),
-                     Test("RightShiftTester", "/integration"))
+                     Test("RightShiftTester", "/integration"),
+                     Test("MemTester", "/integration"))
       
 
   runTests foreach { test =>

--- a/test/integration/MemTester.fir
+++ b/test/integration/MemTester.fir
@@ -1,0 +1,55 @@
+
+circuit MemTester :
+  module ReadWrite :
+    input clk : Clock
+    input reset : UInt<1>
+
+    reg n : UInt<32>, clk with :
+      reset => (reset, UInt(0))
+
+    reg wmode : UInt<1>, clk with : 
+      reset => (reset, UInt(1))
+    wmode <= not(wmode)
+
+    reg addr : UInt<5>, clk with :
+      reset => (reset, UInt(0))
+
+    when eq(wmode, UInt(0)) :
+      n <= add(n, UInt(1))
+      addr <= add(addr, UInt(1))
+
+    mem m :
+      data-type => UInt<32>
+      depth => 32
+      read-latency => 0
+      write-latency => 1
+      readwriter => rw
+      read-under-write => undefined
+    m.rw.clk <= clk
+    m.rw.addr <= addr
+    m.rw.wmode <= wmode
+    m.rw.data <= n
+    m.rw.mask <= UInt(1)
+    m.rw.en <= UInt(1)
+
+    when not(reset) :
+      when eq(wmode, UInt(0)) :
+        when neq(m.rw.rdata, n) :
+          printf(clk, UInt(1), "Assertion failed! m.rw.data has the wrong value!\n")
+          stop(clk, UInt(1), 1)
+
+  module MemTester :
+    input clk : Clock
+    input reset : UInt<1>
+
+    reg count : UInt<32>, clk with :
+      reset => (reset, UInt(100))
+    count <= tail(sub(count, UInt(1)), 1)
+
+    inst rwMod of ReadWrite
+    rwMod.clk <= clk
+    rwMod.reset <= reset
+
+    when eq(count, UInt(0)) :
+      stop(clk, UInt(1), 0)
+


### PR DESCRIPTION
This fixes a bug where LowerTypes was using the obsolete field rmode instead of wmode for readwrite ports of memories.

It also fixes a bug where readwrite ports weren't properly supported and adds an executable test to check that they are.