### PR TITLE
Remove Verilator Warnings

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -80,17 +80,19 @@ object VerilogCompiler extends Compiler {
     InferTypes,
     ResolveGenders,
     InferWidths,
-    Legalize,
     LowerTypes,
     ResolveKinds,
     InferTypes,
     ResolveGenders,
     InferWidths,
-    SplitExp,
+    RemoveValidIf,
     ConstProp,
+    PadWidths,
+    VerilogWrap,
+    SplitExpressions,
     CommonSubexpressionElimination,
     DeadCodeElimination,
-    VerilogWrap,
+    ConstProp,
     VerilogRename
   )
   def run(c: Circuit, w: Writer)

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -80,6 +80,7 @@ object VerilogCompiler extends Compiler {
     InferTypes,
     ResolveGenders,
     InferWidths,
+    Legalize,
     LowerTypes,
     ResolveKinds,
     InferTypes,

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -93,7 +93,6 @@ object VerilogCompiler extends Compiler {
     SplitExpressions,
     CommonSubexpressionElimination,
     DeadCodeElimination,
-    ConstProp,
     VerilogRename
   )
   def run(c: Circuit, w: Writer)

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -202,6 +202,7 @@ class VerilogEmitter extends Emitter {
          case AS_UINT_OP => Seq("$unsigned(",a0(),")")
          case AS_SINT_OP => Seq("$signed(",a0(),")")
          case AS_CLOCK_OP => Seq("$unsigned(",a0(),")")
+         case DSHLW_OP => Seq(cast(a0())," << ", a1())
          case DYN_SHIFT_LEFT_OP => Seq(cast(a0())," << ", a1())
          case DYN_SHIFT_RIGHT_OP => {
             (doprim.tpe) match {
@@ -209,6 +210,7 @@ class VerilogEmitter extends Emitter {
                case (t) => Seq(cast(a0())," >> ",a1())
             }
          }
+         case SHLW_OP => Seq(cast(a0())," << ", c0())
          case SHIFT_LEFT_OP => Seq(cast(a0())," << ",c0())
          case SHIFT_RIGHT_OP => {
            if (c0 >= long_BANG(tpe(a0)))

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -350,7 +350,7 @@ class VerilogEmitter extends Emitter {
          val wx = ((long_BANG(t) + 31) / 32).toInt
          val tx = SIntType(IntWidth(wx * 32))
          val rand = Seq("{",wx.toString,"{",ran,"}}")
-         declare("wire",nx,tx)
+         declare("reg",nx,tx)
          initials += Seq(wref(nx,tx)," = ",rand,";")
          Seq(nx,"[",long_BANG(t) - 1,":0]")
       }

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -69,10 +69,6 @@ class VerilogEmitter extends Emitter {
       }
    }
    def not_empty (s:ArrayBuffer[_]) : Boolean = if (s.size == 0) false else true
-   def rand_string (t:Type) : Seq[Any] = {
-      val wx = ((long_BANG(t) + 31) / 32).toInt
-      Seq("{",wx.toString,"{",ran,"}}")
-   }
    def emit (x:Any) = emit2(x,0)
    def emit2 (x:Any, top:Int) : Unit = {
       def cast (e:Expression) : Any = {
@@ -194,8 +190,13 @@ class VerilogEmitter extends Emitter {
             val diff = (c0() - w)
             if (w == 0) Seq(a0())
             else doprim.tpe match {
-               case (t:SIntType) => Seq("{{",diff,"{",a0(),"[",w - 1,"]}}, ",a0()," }")
-               case (t) => Seq("{{",diff,"'d0 }, ",a0()," }")
+               // Either sign extend or zero extend.
+               case (t:SIntType) => {
+                  // If width == 1, don't extract bit
+                  if (w == 1) Seq("{", c0(),"{", a0(), "}}")
+                  else Seq("{{", diff, "{", a0(), "[", w - 1,"]}},", a0(), "}")
+               }
+               case (t) => Seq("{{", diff, "'d0}, ", a0(), "}")
             }
          }
          case AS_UINT_OP => Seq("$unsigned(",a0(),")")
@@ -248,7 +249,9 @@ class VerilogEmitter extends Emitter {
          }
          case CONCAT_OP => Seq("{",cast(a0()),",",cast(a1()),"}")
          case BITS_SELECT_OP => {
-            if (c0() == c1()) Seq(a0(),"[",c0(),"]")
+            // If selecting zeroth bit and single-bit wire, just emit the wire
+            if (c0() == 0 && c1() == 0 && long_BANG(tpe(a0())) == 1) Seq(a0())
+            else if (c0() == c1()) Seq(a0(),"[",c0(),"]")
             else Seq(a0(),"[",c0(),":",c1(),"]")
          }
          case HEAD_OP => {
@@ -338,11 +341,23 @@ class VerilogEmitter extends Emitter {
             at_clock(clk) += Seq("end")
          }
       }
+      // Declares an intermediate wire to hold a large enough random number.
+      // Then, return the correct number of bits selected from the random value
+      def rand_string (t:Type) : Seq[Any] = {
+         val nx = namespace.newTemp
+         val wx = ((long_BANG(t) + 31) / 32).toInt
+         val tx = SIntType(IntWidth(wx * 32))
+         val rand = Seq("{",wx.toString,"{",ran,"}}")
+         declare("wire",nx,tx)
+         initials += Seq(wref(nx,tx)," = ",rand,";")
+         Seq(nx,"[",long_BANG(t) - 1,":0]")
+      }
       def initialize (e:Expression) = initials += Seq(e," = ",rand_string(tpe(e)),";")
       def initialize_mem(s: DefMemory) = {
-        initials += Seq("for (initvar = 0; initvar < ", s.depth, "; initvar = initvar+1)")
         val index = WRef("initvar", s.data_type, ExpKind(), UNKNOWNGENDER)
-        initials += Seq(tab, WSubAccess(wref(s.name, s.data_type), index, s.data_type, FEMALE), " = ", rand_string(s.data_type), ";")
+        val rstring = rand_string(s.data_type)
+        initials += Seq("for (initvar = 0; initvar < ", s.depth, "; initvar = initvar+1)")
+        initials += Seq(tab, WSubAccess(wref(s.name, s.data_type), index, s.data_type, FEMALE), " = ", rstring,";")
       }
       def instantiate (n:String,m:String,es:Seq[Expression]) = {
          instdeclares += Seq(m," ",n," (")
@@ -459,17 +474,16 @@ class VerilogEmitter extends Emitter {
                   val data = mem_exp(r,"data")
                   val addr = mem_exp(r,"addr")
                   val en = mem_exp(r,"en")
-                  val clk = mem_exp(r,"clk")
+                  //Ports should share an always@posedge, so can't have intermediary wire
+                  val clk = netlist(mem_exp(r,"clk")) 
                   
                   declare("wire",LowerTypes.loweredName(data),tpe(data))
                   declare("wire",LowerTypes.loweredName(addr),tpe(addr))
                   declare("wire",LowerTypes.loweredName(en),tpe(en))
-                  declare("wire",LowerTypes.loweredName(clk),tpe(clk))
    
                   //; Read port
                   assign(addr,netlist(addr)) //;Connects value to m.r.addr
                   assign(en,netlist(en))     //;Connects value to m.r.en
-                  assign(clk,netlist(clk))   //;Connects value to m.r.clk
                   val addrx = delay(addr,s.read_latency,clk)
                   val enx = delay(en,s.read_latency,clk)
                   val mem_port = WSubAccess(mem,addrx,s.data_type,UNKNOWNGENDER)
@@ -481,20 +495,19 @@ class VerilogEmitter extends Emitter {
                   val addr = mem_exp(w,"addr")
                   val mask = mem_exp(w,"mask")
                   val en = mem_exp(w,"en")
-                  val clk = mem_exp(w,"clk")
+                  //Ports should share an always@posedge, so can't have intermediary wire
+                  val clk = netlist(mem_exp(w,"clk"))
                   
                   declare("wire",LowerTypes.loweredName(data),tpe(data))
                   declare("wire",LowerTypes.loweredName(addr),tpe(addr))
                   declare("wire",LowerTypes.loweredName(mask),tpe(mask))
                   declare("wire",LowerTypes.loweredName(en),tpe(en))
-                  declare("wire",LowerTypes.loweredName(clk),tpe(clk))
    
                   //; Write port
                   assign(data,netlist(data))
                   assign(addr,netlist(addr))
                   assign(mask,netlist(mask))
                   assign(en,netlist(en))
-                  assign(clk,netlist(clk))
    
                   val datax = delay(data,s.write_latency - 1,clk)
                   val addrx = delay(addr,s.write_latency - 1,clk)
@@ -511,7 +524,8 @@ class VerilogEmitter extends Emitter {
                   val mask = mem_exp(rw,"mask")
                   val addr = mem_exp(rw,"addr")
                   val en = mem_exp(rw,"en")
-                  val clk = mem_exp(rw,"clk")
+                  //Ports should share an always@posedge, so can't have intermediary wire
+                  val clk = netlist(mem_exp(rw,"clk"))
                   
                   declare("wire",LowerTypes.loweredName(wmode),tpe(wmode))
                   declare("wire",LowerTypes.loweredName(rdata),tpe(rdata))
@@ -519,10 +533,8 @@ class VerilogEmitter extends Emitter {
                   declare("wire",LowerTypes.loweredName(mask),tpe(mask))
                   declare("wire",LowerTypes.loweredName(addr),tpe(addr))
                   declare("wire",LowerTypes.loweredName(en),tpe(en))
-                  declare("wire",LowerTypes.loweredName(clk),tpe(clk))
    
                   //; Assigned to lowered wires of each
-                  assign(clk,netlist(clk))
                   assign(addr,netlist(addr))
                   assign(data,netlist(data))
                   assign(addr,netlist(addr))
@@ -574,6 +586,9 @@ class VerilogEmitter extends Emitter {
             emit(Seq("`ifndef SYNTHESIS"))
             emit(Seq("  integer initvar;"))
             emit(Seq("  initial begin"))
+            // This enables test benches to set the random values at time 0.001,
+            //  then start the simulation later
+            // Verilator does not support delay statements, so they are omitted.
             emit(Seq("    `ifndef verilator"))
             emit(Seq("      #0.002;"))
             emit(Seq("    `endif"))

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -57,8 +57,15 @@ case class WVoid() extends Expression { def tpe = UnknownType() }
 case class WInvalid() extends Expression { def tpe = UnknownType() }
 case class WDefInstance(info:Info,name:String,module:String,tpe:Type) extends Stmt 
 
-case object ADDW_OP extends PrimOp 
+// Resultant width is the same as the maximum input width
+case object ADDW_OP extends PrimOp
+// Resultant width is the same as the maximum input width
 case object SUBW_OP extends PrimOp
+// Resultant width is the same as input argument width
+case object DSHLW_OP extends PrimOp
+// Resultant width is the same as input argument width
+case object SHLW_OP extends PrimOp
+
 
 object WrappedExpression {
    def apply (e:Expression) = new WrappedExpression(e)

--- a/src/main/scala/firrtl/passes/ConstProp.scala
+++ b/src/main/scala/firrtl/passes/ConstProp.scala
@@ -125,6 +125,82 @@ object ConstProp extends Pass {
     }
   }
 
+  private def foldComparison(e: DoPrim) = {
+    def foldIfZeroedArg(x: Expression): Expression = {
+      def isUInt(e: Expression): Boolean = tpe(e) match {
+        case UIntType(_) => true
+        case _ => false
+      }
+      def isZero(e: Expression) = e match {
+          case UIntValue(value,_) => value == BigInt(0)
+          case SIntValue(value,_) => value == BigInt(0)
+          case _ => false
+        }
+      x match {
+        case DoPrim(LESS_OP,      Seq(a,b),_,_) if(isUInt(a) && isZero(b)) => zero
+        case DoPrim(LESS_EQ_OP,   Seq(a,b),_,_) if(isZero(a) && isUInt(b)) => one
+        case DoPrim(GREATER_OP,   Seq(a,b),_,_) if(isZero(a) && isUInt(b)) => zero
+        case DoPrim(GREATER_EQ_OP,Seq(a,b),_,_) if(isUInt(a) && isZero(b)) => one
+        case e => e
+      }
+    }
+
+    def foldIfOutsideRange(x: Expression): Expression = {
+      //Note, only abides by a partial ordering
+      case class Range(min: BigInt, max: BigInt) {
+        def === (that: Range) =
+          Seq(this.min, this.max, that.min, that.max)
+            .sliding(2,1)
+            .map(x => x(0) == x(1))
+            .reduce(_ && _)
+        def > (that: Range) = this.min > that.max
+        def >= (that: Range) = this.min >= that.max
+        def < (that: Range) = this.max < that.min
+        def <= (that: Range) = this.max <= that.min
+      }
+      def range(e: Expression): Range = e match {
+        case UIntValue(value, _) => Range(value, value)
+        case SIntValue(value, _) => Range(value, value)
+        case _ => tpe(e) match {
+          case SIntType(IntWidth(width)) => Range(
+            min = BigInt(0) - BigInt(2).pow(width.toInt - 1),
+            max = BigInt(2).pow(width.toInt - 1) - BigInt(1)
+          )
+          case UIntType(IntWidth(width)) => Range(
+            min = BigInt(0),
+            max = BigInt(2).pow(width.toInt) - BigInt(1)
+          )
+        }
+      }
+      // Calculates an expression's range of values
+      x match {
+        case e: DoPrim => {
+          def r0 = range(e.args(0))
+          def r1 = range(e.args(1))
+          e.op match {
+            // Always true
+            case LESS_OP       if (r0 < r1) => one
+            case LESS_EQ_OP    if (r0 <= r1) => one
+            case GREATER_OP    if (r0 > r1) => one
+            case GREATER_EQ_OP if (r0 >= r1) => one
+            //case EQUAL_OP      if (r0 === r1) => one
+            //case NEQUAL_OP     if ((r0 < r1) || (r0 > r1)) => one
+            // Always false
+            case LESS_OP       if (r0 >= r1) => zero
+            case LESS_EQ_OP    if (r0 > r1) => zero
+            case GREATER_OP    if (r0 <= r1) => zero
+            case GREATER_EQ_OP if (r0 < r1) => zero
+            //case EQUAL_OP      if ((r0 < r1) || (r0 > r1)) => zero
+            //case NEQUAL_OP     if (r0 === r1) => zero
+            case _ => e
+          }
+        }
+        case e => e
+      }
+    }
+    foldIfZeroedArg(foldIfOutsideRange(e))
+  }
+
   private def constPropPrim(e: DoPrim): Expression = e.op match {
     case SHIFT_LEFT_OP => foldShiftLeft(e)
     case SHIFT_RIGHT_OP => foldShiftRight(e)
@@ -134,6 +210,7 @@ object ConstProp extends Pass {
     case XOR_OP => FoldXOR(e)
     case EQUAL_OP => FoldEqual(e)
     case NEQUAL_OP => FoldNotEqual(e)
+    case LESS_OP|LESS_EQ_OP|GREATER_OP|GREATER_EQ_OP => foldComparison(e)
     case NOT_OP => e.args(0) match {
       case UIntValue(v, IntWidth(w)) => UIntValue(v ^ ((BigInt(1) << w.toInt) - 1), IntWidth(w))
       case _ => e

--- a/src/main/scala/firrtl/passes/ConstProp.scala
+++ b/src/main/scala/firrtl/passes/ConstProp.scala
@@ -183,15 +183,11 @@ object ConstProp extends Pass {
             case LESS_EQ_OP    if (r0 <= r1) => one
             case GREATER_OP    if (r0 > r1) => one
             case GREATER_EQ_OP if (r0 >= r1) => one
-            //case EQUAL_OP      if (r0 === r1) => one
-            //case NEQUAL_OP     if ((r0 < r1) || (r0 > r1)) => one
             // Always false
             case LESS_OP       if (r0 >= r1) => zero
             case LESS_EQ_OP    if (r0 > r1) => zero
             case GREATER_OP    if (r0 <= r1) => zero
             case GREATER_EQ_OP if (r0 < r1) => zero
-            //case EQUAL_OP      if ((r0 < r1) || (r0 > r1)) => zero
-            //case NEQUAL_OP     if (r0 === r1) => zero
             case _ => e
           }
         }

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -1,0 +1,80 @@
+package firrtl
+package passes
+
+import firrtl.Mappers.{ExpMap, StmtMap}
+import firrtl.Utils.{tpe, long_BANG}
+
+// Makes all implicit width extensions and truncations explicit
+object PadWidths extends Pass {
+   def name = "Pad Widths"
+   private def width(t: Type): Int = long_BANG(t).toInt
+   private def width(e: Expression): Int = width(tpe(e))
+   // Returns an expression with the correct integer width
+   private def fixup(i: Int)(e: Expression) = {
+      def tx = tpe(e) match {
+         case t: UIntType => UIntType(IntWidth(i))
+         case t: SIntType => SIntType(IntWidth(i))
+         // default case should never be reached
+      }
+      if (i > width(e))
+         DoPrim(PAD_OP, Seq(e), Seq(i), tx)
+      else if (i < width(e))
+         DoPrim(BITS_SELECT_OP, Seq(e), Seq(i - 1, 0), tx)
+      else e
+   }
+   // Recursive, updates expression so children exp's have correct widths
+   private def onExp(e: Expression): Expression = {
+      val sensitiveOps = Seq(
+         LESS_OP, LESS_EQ_OP, GREATER_OP, GREATER_EQ_OP, EQUAL_OP,
+         NEQUAL_OP, NOT_OP, AND_OP, OR_OP, XOR_OP, ADD_OP, SUB_OP,
+         MUL_OP, DIV_OP, REM_OP, SHIFT_RIGHT_OP)
+      val x = e map onExp
+      x match {
+         case Mux(cond, tval, fval, tpe) => {
+            val tvalx = fixup(width(tpe))(tval)
+            val fvalx = fixup(width(tpe))(fval)
+            Mux(cond, tvalx, fvalx, tpe)
+         }
+         case DoPrim(op, args, consts, tpe) => op match {
+            case _ if sensitiveOps.contains(op) => {
+               val i = args.map(a => width(a)).foldLeft(0) {(a, b) => math.max(a, b)}
+               x map fixup(i)
+            }
+            case DYN_SHIFT_LEFT_OP => {
+               // special case as args aren't all same width
+               val ax = fixup(width(tpe))(args(0))
+               DoPrim(DSHLW_OP, Seq(ax, args(1)), consts, tpe)
+            }
+            case SHIFT_LEFT_OP => {
+               // special case as arg should be same width as result
+               val ax = fixup(width(tpe))(args(0))
+               DoPrim(SHLW_OP, Seq(ax), consts, tpe)
+            }
+            case _ => x
+         }
+         case ValidIf(cond, value, tpe) => ValidIf(cond, fixup(width(tpe))(value), tpe)
+         case x => x
+      }
+   }
+   // Recursive. Fixes assignments and register initialization widths
+   private def onStmt(s: Stmt): Stmt = {
+      s map onExp match {
+         case s: Connect => {
+            val ex = fixup(width(s.loc))(s.exp)
+            Connect(s.info, s.loc, ex)
+         }
+         case s: DefRegister => {
+            val ex = fixup(width(s.tpe))(s.init)
+            DefRegister(s.info, s.name, s.tpe, s.clock, s.reset, ex)
+         }
+         case s => s map onStmt
+      }
+   }
+   private def onModule(m: Module): Module = {
+      m match {
+         case m:InModule => InModule(m.info, m.name, m.ports, onStmt(m.body))
+         case m:ExModule => m
+      }
+   }
+   def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule _), c.main)
+}

--- a/src/main/scala/firrtl/passes/RemoveValidIf.scala
+++ b/src/main/scala/firrtl/passes/RemoveValidIf.scala
@@ -1,0 +1,26 @@
+package firrtl
+package passes
+import firrtl.Mappers.{ExpMap, StmtMap}
+
+// Removes ValidIf as an optimization
+object RemoveValidIf extends Pass {
+   def name = "Remove ValidIfs"
+   // Recursive. Removes ValidIf's
+   private def onExp(e: Expression): Expression = {
+      e map onExp match {
+         case ValidIf(cond, value, tpe) => value
+         case x => x
+      }
+   }
+   // Recursive.
+   private def onStmt(s: Stmt): Stmt = s map onStmt map onExp
+
+   private def onModule(m: Module): Module = {
+      m match {
+         case m:InModule => InModule(m.info, m.name, m.ports, onStmt(m.body))
+         case m:ExModule => m
+      }
+   }
+
+   def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule _), c.main)
+}

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -1,0 +1,65 @@
+package firrtl
+package passes
+
+import firrtl.Mappers.{ExpMap, StmtMap}
+import firrtl.Utils.{tpe, kind, gender, info}
+import scala.collection.mutable
+
+
+// Splits compound expressions into simple expressions
+//  and named intermediate nodes
+object SplitExpressions extends Pass {
+   def name = "Split Expressions"
+   private def onModule(m: InModule): InModule = {
+      val namespace = Namespace(m)
+      def onStmt(s: Stmt): Stmt = {
+         val v = mutable.ArrayBuffer[Stmt]()
+         // Splits current expression if needed
+         // Adds named temporaries to v
+         def split(e: Expression): Expression = e match {
+            case e: DoPrim => {
+               val name = namespace.newTemp
+               v += DefNode(info(s), name, e)
+               WRef(name, tpe(e), kind(e), gender(e))
+            }
+            case e: Mux => {
+               val name = namespace.newTemp
+               v += DefNode(info(s), name, e)
+               WRef(name, tpe(e), kind(e), gender(e))
+            }
+            case e: ValidIf => {
+               val name = namespace.newTemp
+               v += DefNode(info(s), name, e)
+               WRef(name, tpe(e), kind(e), gender(e))
+            }
+            case e => e
+         }
+         // Recursive. Splits compound nodes
+         def onExp(e: Expression): Expression = {
+            val ex = e map onExp
+            ex match {
+               case (_: DoPrim) => ex map split
+               case v => v
+            }
+         }
+         val x = s map onExp
+         x match {
+            case x: Begin => x map onStmt
+            case x: Empty => x
+            case x => {
+               v += x
+               if (v.size > 1) Begin(v.toVector)
+               else v(0)
+            }
+         }
+      }
+      InModule(m.info, m.name, m.ports, onStmt(m.body))
+   }
+   def run(c: Circuit): Circuit = {
+      val modulesx = c.modules.map( _ match {
+         case (m:InModule) => onModule(m)
+         case (m:ExModule) => m
+      })
+      Circuit(c.info, modulesx, c.main)
+   }
+}

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -1,0 +1,350 @@
+package firrtlTests
+
+import org.scalatest.Matchers
+import java.io.{StringWriter,Writer}
+import firrtl._
+import firrtl.passes._
+
+// Tests the following cases for constant propagation:
+//   1) Unsigned integers are always greater than or
+//        equal to zero
+//   2) Values are always smaller than a number greater
+//        than their maximum value
+//   3) Values are always greater than a number smaller
+//        than their minimum value
+class ConstantPropagationSpec extends FirrtlFlatSpec {
+  val passes = Seq(
+      ToWorkingIR,
+      ResolveKinds,
+      InferTypes,
+      ResolveGenders,
+      InferWidths,
+      ConstProp)
+  def parse(input: String): Circuit = Parser.parse("", input.split("\n").toIterator, false)
+  private def exec (input: String) = {
+    passes.foldLeft(parse(input)) {
+      (c: Circuit, p: Pass) => p.run(c)
+    }.serialize
+  }
+   // =============================
+   "The rule x >= 0 " should " always be true if x is a UInt" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= geq(x, UInt(0))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= UInt<1>("h1")
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule x < 0 " should " never be true if x is a UInt" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= lt(x, UInt(0))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 0 <= x " should " always be true if x is a UInt" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= leq(UInt(0),x)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 0 > x " should " never be true if x is a UInt" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= gt(UInt(0),x)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 1 < 3 " should " always be true" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= lt(UInt(0),UInt(3))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule x < 8 " should " always be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= lt(x,UInt(8))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule x <= 7 " should " always be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= leq(x,UInt(7))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 8 > x" should " always be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= gt(UInt(8),x)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 7 >= x" should " always be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= geq(UInt(7),x)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 10 == 10" should " always be true" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= eq(UInt(10),UInt(10))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(1)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule x == z " should " not be true even if they have the same number of bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    input z : UInt<3>
+    output y : UInt<1>
+    y <= eq(x,z)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    input z : UInt<3>
+    output y : UInt<1>
+    y <= eq(x,z)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 10 != 10 " should " always be false" in {
+      val input =
+"""circuit Top :
+  module Top :
+    output y : UInt<1>
+    y <= neq(UInt(10),UInt(10))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    output y : UInt<1>
+    y <= UInt(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+   // =============================
+   "The rule 1 >= 3 " should " always be false" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= geq(UInt(1),UInt(3))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule x >= 8 " should " never be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= geq(x,UInt(8))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule x > 7 " should " never be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= gt(x,UInt(7))
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 8 <= x" should " never be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= leq(UInt(8),x)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+
+   // =============================
+   "The rule 7 < x" should " never be true if x only has 3 bits" in {
+      val input =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= lt(UInt(7),x)
+"""
+      val check =
+"""circuit Top :
+  module Top :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= UInt<1>(0)
+"""
+      (parse(exec(input))) should be (parse(check))
+   }
+}


### PR DESCRIPTION
The following changes were necessary to emit warning-free Verilator Verilog:

- Remove ValidIfs. This pass replaces ValidIfs with their value, with the hopes of future simplification of Emitter.scala
- Pad Widths. This pass pads/truncates assignments and expressions (e.g. mux inputs are the same width)
- ConstProp case. This addition simplifies two cases: comparisons against zero, and comparisons against a value outside the range of a wire.
- Memory ports are under same clock
- Randomized values are bit-selected from (to eliminate corresponding Verilator warning)