### PR TITLE
Prototype supporting file info

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -37,16 +37,16 @@ grammar FIRRTL;
 
 // Does there have to be at least one module?
 circuit
-  : 'circuit' id ':' '{' module* '}'
+  : info? 'circuit' id ':' '{' module* '}'
   ;
 
 module
-  : 'module' id ':' '{' port* block '}'
-  | 'extmodule' id ':' '{' port* '}'
+  : info? 'module' id ':' '{' port* block '}'
+  | info? 'extmodule' id ':' '{' port* '}'
   ;
 
 port
-  : dir id ':' type
+  : info? dir id ':' type
   ;
 
 dir
@@ -72,9 +72,9 @@ block
   ; 
 
 stmt
-  : 'wire' id ':' type
-  | 'reg' id ':' type exp ('with' ':' '{' 'reset' '=>' '(' exp exp ')' '}')?
-  | 'mem' id ':' '{' ( 'data-type' '=>' type 
+  : info? 'wire' id ':' type
+  | info? 'reg' id ':' type exp ('with' ':' '{' 'reset' '=>' '(' exp exp ')' '}')?
+  | info? 'mem' id ':' '{' ( 'data-type' '=>' type
                      | 'depth' '=>' IntLit
                      | 'read-latency' '=>' IntLit
                      | 'write-latency' '=>' IntLit
@@ -84,18 +84,22 @@ stmt
                      | 'readwriter' '=>' id 
                      )*
                  '}'
-  | 'cmem' id ':' type
-  | 'smem' id ':' type
-  | mdir 'mport' id '=' id '[' exp ']' exp
-  | 'inst' id 'of' id 
-  | 'node' id '=' exp
-  | exp '<=' exp 
-  | exp '<-' exp
-  | exp 'is' 'invalid'
-  | 'when' exp ':' '{' block '}' ( 'else' ':' '{' block '}' )? 
-  | 'stop(' exp exp IntLit ')'
-  | 'printf(' exp exp StringLit (exp)* ')'
-  | 'skip'
+  | info? 'cmem' id ':' type
+  | info? 'smem' id ':' type
+  | info? mdir 'mport' id '=' id '[' exp ']' exp
+  | info? 'inst' id 'of' id
+  | info? 'node' id '=' exp
+  | info? exp '<=' exp
+  | info? exp '<-' exp
+  | info? exp 'is' 'invalid'
+  | info? 'when' exp ':' '{' block '}' ( 'else' ':' '{' block '}' )?
+  | info? 'stop(' exp exp IntLit ')'
+  | info? 'printf(' exp exp StringLit (exp)* ')'
+  | info? 'skip'
+  ;
+
+info
+  : StringLit
   ;
 
 mdir

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -35,20 +35,23 @@ import scala.sys.process._
 import com.typesafe.scalalogging.LazyLogging
 
 import Utils._
+import Parser.{InfoMode, IgnoreInfo, UseInfo, GenInfo, AppendInfo}
 
 object Driver extends LazyLogging {
   private val usage = """
 Usage: sbt "run-main firrtl.Driver -i <input_file> -o <output_file> -X <compiler>"
-       firrtl -i <input_file> -o <output_file> -X <compiler>
+       firrtl -i <input_file> -o <output_file> -X <compiler> [options]
 Options:
-  -X <compiler>    Specify the target language
-                   Currently supported: verilog firrtl
+  -X <compiler>         Specify the target language
+                        Currently supported: verilog firrtl
+  --info-mode=<mode>    Specify Info Mode
+                        Supported modes: ignore, use, gen, append
   """
   private val defaultOptions = Map[Symbol, Any]().withDefaultValue(false)
 
-  def compile(input: String, output: String, compiler: Compiler)
+  def compile(input: String, output: String, compiler: Compiler, infoMode: InfoMode = IgnoreInfo)
   {
-    val parsedInput = Parser.parse(input, Source.fromFile(input).getLines)
+    val parsedInput = Parser.parse(input, Source.fromFile(input).getLines, infoMode)
     val writerOutput = new PrintWriter(new File(output))
     compiler.run(parsedInput, writerOutput)
     writerOutput.close
@@ -68,6 +71,8 @@ Options:
                   nextOption(map ++ Map('input -> value), tail)
         case "-o" :: value :: tail =>
                   nextOption(map ++ Map('output -> value), tail)
+        case "--info-mode" :: value :: tail =>
+                  nextOption(map ++ Map('infoMode -> value), tail)
         case ("-h" | "--help") :: tail =>
                   nextOption(map ++ Map('help -> true), tail)
         case option :: tail =>
@@ -89,10 +94,16 @@ Options:
       case s: String => s
       case false => throw new Exception("No output file provided!" + usage)
     }
+    val infoMode = options('infoMode) match {
+      case ("use" | false) => UseInfo
+      case "ignore" => IgnoreInfo
+      case "gen" => GenInfo
+      case "append" => AppendInfo
+    }
 
     options('compiler) match {
-      case "verilog" => compile(input, output, VerilogCompiler)
-      case "firrtl" => compile(input, output, FIRRTLCompiler)
+      case "verilog" => compile(input, output, VerilogCompiler, infoMode)
+      case "firrtl" => compile(input, output, FIRRTLCompiler, infoMode)
       case other => throw new Exception("Invalid compiler! " + other)
     }
   }

--- a/src/main/scala/firrtl/IR.scala
+++ b/src/main/scala/firrtl/IR.scala
@@ -36,10 +36,10 @@ Member of most Stmt case classes.
 */
 trait Info
 case object NoInfo extends Info {
-  override def toString(): String = "NoFileInfo"
+  override def toString(): String = ""
 }
-case class FileInfo(file: String, line: Int, column: Int) extends Info {
-  override def toString(): String = s"$file@$line.$column"
+case class FileInfo(info: StringLit) extends Info {
+  override def toString(): String = "\"" + info.serialize + "\" "
 }
 
 class FIRRTLException(str: String) extends Exception(str)

--- a/src/main/scala/firrtl/Serialize.scala
+++ b/src/main/scala/firrtl/Serialize.scala
@@ -54,6 +54,8 @@ private object Serialize {
     if (bi < BigInt(0)) "\"h" + bi.toString(16).substring(1) + "\""
     else "\"h" + bi.toString(16) + "\""
 
+  def serialize(info: Info): String = info.toString
+
   def serialize(op: PrimOp): String = op.getString
 
   def serialize(lit: StringLit): String = FIRRTLStringLitHandler.escape(lit)
@@ -80,17 +82,17 @@ private object Serialize {
 
   def serialize(stmt: Stmt): String = {
     stmt match {
-      case w: DefWire => s"wire ${w.name} : ${serialize(w.tpe)}"
+      case w: DefWire => s"${w.info}wire ${w.name} : ${serialize(w.tpe)}"
       case r: DefRegister =>
-        val str = new StringBuilder(s"reg ${r.name} : ${serialize(r.tpe)}, ${serialize(r.clock)} with : ")
+        val str = new StringBuilder(s"${r.info}reg ${r.name} : ${serialize(r.tpe)}, ${serialize(r.clock)} with : ")
         withIndent {
           str ++= newline + s"reset => (${serialize(r.reset)}, ${serialize(r.init)})"
         }
         str.toString
-      case i: DefInstance => s"inst ${i.name} of ${i.module}"
-      case i: WDefInstance => s"inst ${i.name} of ${i.module}"
+      case i: DefInstance => s"${i.info}inst ${i.name} of ${i.module}"
+      case i: WDefInstance => s"${i.info}inst ${i.name} of ${i.module}"
       case m: DefMemory => {
-        val str = new StringBuilder(s"mem ${m.name} : ")
+        val str = new StringBuilder(s"${m.info}mem ${m.name} : ")
         withIndent {
           str ++= newline +
             s"data-type => ${serialize(m.data_type)}" + newline +
@@ -107,11 +109,11 @@ private object Serialize {
         }
         str.result
       }
-      case n: DefNode => s"node ${n.name} = ${serialize(n.value)}"
-      case c: Connect => s"${serialize(c.loc)} <= ${serialize(c.exp)}"
-      case b: BulkConnect => s"${serialize(b.loc)} <- ${serialize(b.exp)}"
+      case n: DefNode => s"${n.info}node ${n.name} = ${serialize(n.value)}"
+      case c: Connect => s"${c.info}${serialize(c.loc)} <= ${serialize(c.exp)}"
+      case b: BulkConnect => s"${b.info}${serialize(b.loc)} <- ${serialize(b.exp)}"
       case w: Conditionally => {
-        var str = new StringBuilder(s"when ${serialize(w.pred)} : ")
+        var str = new StringBuilder(s"${w.info}when ${serialize(w.pred)} : ")
         withIndent { str ++= newline + serialize(w.conseq) }
         w.alt match {
           case s:Empty => str.result
@@ -130,17 +132,17 @@ private object Serialize {
         }
         s.result
       }
-      case i: IsInvalid => s"${serialize(i.exp)} is invalid"
-      case s: Stop => s"stop(${serialize(s.clk)}, ${serialize(s.en)}, ${s.ret})"
+      case i: IsInvalid => s"${i.info}${serialize(i.exp)} is invalid"
+      case s: Stop => s"${s.info}stop(${serialize(s.clk)}, ${serialize(s.en)}, ${s.ret})"
       case p: Print => {
         val q = '"'.toString
-        s"printf(${serialize(p.clk)}, ${serialize(p.en)}, ${q}${serialize(p.string)}${q}" +
+        s"${p.info}printf(${serialize(p.clk)}, ${serialize(p.en)}, ${q}${serialize(p.string)}${q}" +
                       (if (p.args.nonEmpty) p.args.map(serialize).mkString(", ", ", ", "") else "") + ")"
       }
       case s: Empty => "skip"
       case s: CDefMemory => {
-        if (s.seq) s"smem ${s.name} : ${serialize(s.tpe)} [${s.size}]"
-        else s"cmem ${s.name} : ${serialize(s.tpe)} [${s.size}]"
+        if (s.seq) s"${s.info}smem ${s.name} : ${serialize(s.tpe)} [${s.size}]"
+        else s"${s.info}cmem ${s.name} : ${serialize(s.tpe)} [${s.size}]"
       }
       case s: CDefMPort => {
         val dir = s.direction match {
@@ -149,7 +151,7 @@ private object Serialize {
           case MWrite => "write"
           case MReadWrite => "rdwr"
         }
-        s"${dir} mport ${s.name} = ${s.mem}[${serialize(s.exps(0))}], ${serialize(s.exps(1))}"
+        s"${s.info}${dir} mport ${s.name} = ${s.mem}[${serialize(s.exps(0))}], ${serialize(s.exps(1))}"
       }
     }
   }
@@ -192,12 +194,12 @@ private object Serialize {
   }
 
   def serialize(p: Port): String =
-    s"${serialize(p.direction)} ${p.name} : ${serialize(p.tpe)}"
+    s"${p.info}${serialize(p.direction)} ${p.name} : ${serialize(p.tpe)}"
 
   def serialize(m: Module): String = {
     m match {
       case m: InModule => {
-        var s = new StringBuilder(s"module ${m.name} : ")
+        var s = new StringBuilder(s"${m.info}module ${m.name} : ")
         withIndent {
           s ++= m.ports.map(newline ++ serialize(_)).mkString
           s ++= newline ++ serialize(m.body)
@@ -205,7 +207,7 @@ private object Serialize {
         s.toString
       }
       case m: ExModule => {
-        var s = new StringBuilder(s"extmodule ${m.name} : ")
+        var s = new StringBuilder(s"${m.info}extmodule ${m.name} : ")
         withIndent {
           s ++= m.ports.map(newline ++ serialize(_)).mkString
           s ++= newline
@@ -216,7 +218,7 @@ private object Serialize {
   }
 
   def serialize(c: Circuit): String = {
-    var s = new StringBuilder(s"circuit ${c.main} : ")
+    var s = new StringBuilder(s"${c.info}circuit ${c.main} : ")
     withIndent { s ++= newline ++ c.modules.map(serialize).mkString(newline + newline) }
     s ++= newline ++ newline
     s.toString

--- a/src/test/scala/firrtlTests/CheckInitializationSpec.scala
+++ b/src/test/scala/firrtlTests/CheckInitializationSpec.scala
@@ -31,10 +31,11 @@ import java.io._
 import org.scalatest._
 import org.scalatest.prop._
 import firrtl._
+import firrtl.Parser.IgnoreInfo
 import firrtl.passes._
 
 class CheckInitializationSpec extends FirrtlFlatSpec {
-  private def parse(input: String) = Parser.parse("", input.split("\n").toIterator, false)
+  private def parse(input: String) = Parser.parse("", input.split("\n").toIterator, IgnoreInfo)
   private val passes = Seq(
      ToWorkingIR,
      CheckHighForm,

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -3,6 +3,7 @@ package firrtlTests
 import org.scalatest.Matchers
 import java.io.{StringWriter,Writer}
 import firrtl._
+import firrtl.Parser.IgnoreInfo
 import firrtl.passes._
 
 // Tests the following cases for constant propagation:
@@ -20,7 +21,7 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
       ResolveGenders,
       InferWidths,
       ConstProp)
-  def parse(input: String): Circuit = Parser.parse("", input.split("\n").toIterator, false)
+  def parse(input: String): Circuit = Parser.parse("", input.split("\n").toIterator, IgnoreInfo)
   private def exec (input: String) = {
     passes.foldLeft(parse(input)) {
       (c: Circuit, p: Pass) => p.run(c)

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -32,9 +32,10 @@ import org.scalatest._
 import org.scalatest.prop._
 import firrtl._
 import firrtl.passes._
+import firrtl.Parser.IgnoreInfo
 
 class UnitTests extends FirrtlFlatSpec {
-  def parse (input:String) = Parser.parse("",input.split("\n").toIterator,false)
+  def parse (input:String) = Parser.parse("",input.split("\n").toIterator, IgnoreInfo)
   private def executeTest(input: String, expected: Seq[String], passes: Seq[Pass]) = {
     val c = passes.foldLeft(Parser.parse("", input.split("\n").toIterator)) {
       (c: Circuit, p: Pass) => p.run(c)


### PR DESCRIPTION
Uses same StringLit as Print

Do not merge yet, this is just a prototype.

This PR provides fileinfo as double quoted strings before circuits, modules, ports, and statements. I think we should discuss how we want file info to actually look. In this current implementation, file info goes before the firrtl text and it looks something like this:
```
"TestFileInfo.scala@7.0" circuit Test :
  "TestFileInfo.scala@7.0" module Test :
    "TestFileInfo.scala@9.2" input clk : Clock
    "TestFileInfo.scala@9.2" input reset : UInt<1>

    "TestFileInfo.scala@11.2" reg x : UInt<32>, clk with :
      reset => (reset, UInt(0))

    "TestFileInfo.scala@13.2" x <= add(x, UInt(1))

    "TestFileInfo.scala@15.2" when eq(x, UInt(20)) :
      "TestFileInfo.scala@16.4" stop(clk, UInt(1), 0)
```
Personally I find that unreadable. An alternative would be to put the fileinfo on the previous line:
```
"TestFileInfo.scala@7.0"
circuit Test :  
  "TestFileInfo.scala@7.0"
  module Test : 
    "TestFileInfo.scala@9.2"
    input clk : Clock 
    "TestFileInfo.scala@9.2"
    input reset : UInt<1>
    
    "TestFileInfo.scala@11.2"
    reg x : UInt<32>, clk with : 
      reset => (reset, UInt(0))

    "TestFileInfo.scala@13.2"
    x <= add(x, UInt(1)) 

    "TestFileInfo.scala@15.2"
    when eq(x, UInt(20)) : 
      "TestFileInfo.scala@16.4"
      stop(clk, UInt(1), 0)
```
Still difficult to read, but with syntax highlighting it might be okay. I think putting the file info after the firrtl text is better: 
```
circuit Test : "TestFileInfo.scala@7.0"  
  module Test : "TestFileInfo.scala@7.0" 
    input clk : Clock "TestFileInfo.scala@9.2"  
    input reset : UInt<1> "TestFileInfo.scala@9.2" 
    
    reg x : UInt<32>, clk with : "TestFileInfo.scala@11.2"
      reset => (reset, UInt(0))
    
    x <= add(x, UInt(1)) "TestFileInfo.scala@13.2" 
    
    when eq(x, UInt(20)) : "TestFileInfo.scala@15.2"
      stop(clk, UInt(1), 0) "TestFileInfo.scala@16.4"
```
With proper syntax highlighting I think this is the most readable.