### PR TITLE
Implement file info

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -37,16 +37,16 @@ grammar FIRRTL;
 
 // Does there have to be at least one module?
 circuit
-  : 'circuit' id ':' '{' module* '}'
+  : 'circuit' id ':' info? '{' module* '}'
   ;
 
 module
-  : 'module' id ':' '{' port* block '}'
-  | 'extmodule' id ':' '{' port* '}'
+  : 'module' id ':' info? '{' port* block '}'
+  | 'extmodule' id ':' info? '{' port* '}'
   ;
 
 port
-  : dir id ':' type
+  : dir id ':' type info?
   ;
 
 dir
@@ -72,30 +72,35 @@ block
   ; 
 
 stmt
-  : 'wire' id ':' type
-  | 'reg' id ':' type exp ('with' ':' '{' 'reset' '=>' '(' exp exp ')' '}')?
-  | 'mem' id ':' '{' ( 'data-type' '=>' type 
+  : 'wire' id ':' type info?
+  | 'reg' id ':' type exp ('with' ':' '{' 'reset' '=>' '(' exp exp ')' '}')? info?
+  | 'mem' id ':' info? '{'
+                     ( 'data-type' '=>' type
                      | 'depth' '=>' IntLit
                      | 'read-latency' '=>' IntLit
                      | 'write-latency' '=>' IntLit
                      | 'read-under-write' '=>' ruw
                      | 'reader' '=>' id
                      | 'writer' '=>' id
-                     | 'readwriter' '=>' id 
+                     | 'readwriter' '=>' id
                      )*
                  '}'
-  | 'cmem' id ':' type
-  | 'smem' id ':' type
-  | mdir 'mport' id '=' id '[' exp ']' exp
-  | 'inst' id 'of' id 
-  | 'node' id '=' exp
-  | exp '<=' exp 
-  | exp '<-' exp
-  | exp 'is' 'invalid'
-  | 'when' exp ':' '{' block '}' ( 'else' ':' '{' block '}' )? 
-  | 'stop(' exp exp IntLit ')'
-  | 'printf(' exp exp StringLit (exp)* ')'
-  | 'skip'
+  | 'cmem' id ':' type info?
+  | 'smem' id ':' type info?
+  | mdir 'mport' id '=' id '[' exp ']' exp info?
+  | 'inst' id 'of' id info?
+  | 'node' id '=' exp info?
+  | exp '<=' exp info?
+  | exp '<-' exp info?
+  | exp 'is' 'invalid' info?
+  | 'when' exp ':' info? '{' block '}' ( 'else' ':' '{' block '}' )?
+  | 'stop(' exp exp IntLit ')' info?
+  | 'printf(' exp exp StringLit (exp)* ')' info?
+  | 'skip' info?
+  ;
+
+info
+  : FileInfo
   ;
 
 mdir
@@ -245,6 +250,9 @@ StringLit
   : '"' ('\\"'|.)*? '"'
   ;
 
+FileInfo
+  : '@[' ('\\]'|.)*? ']'
+  ;
 
 Id
   : IdNondigit

--- a/src/main/scala/firrtl/IR.scala
+++ b/src/main/scala/firrtl/IR.scala
@@ -36,10 +36,10 @@ Member of most Stmt case classes.
 */
 trait Info
 case object NoInfo extends Info {
-  override def toString(): String = "NoFileInfo"
+  override def toString(): String = ""
 }
-case class FileInfo(file: String, line: Int, column: Int) extends Info {
-  override def toString(): String = s"$file@$line.$column"
+case class FileInfo(info: StringLit) extends Info {
+  override def toString(): String = " @[" + info.serialize + "]"
 }
 
 class FIRRTLException(str: String) extends Exception(str)

--- a/src/main/scala/firrtl/Parser.scala
+++ b/src/main/scala/firrtl/Parser.scala
@@ -41,7 +41,7 @@ case class InvalidEscapeCharException(message: String) extends ParserException(m
 object Parser extends LazyLogging
 {
   /** Takes Iterator over lines of FIRRTL, returns AST (root node is Circuit) */
-  def parse(filename: String, lines: Iterator[String], useInfo: Boolean = true): Circuit = {
+  def parse(lines: Iterator[String], infoMode: InfoMode = UseInfo): Circuit = {
     val fixedInput = time("Translator") { Translator.addBrackets(lines) }
     val antlrStream = new ANTLRInputStream(fixedInput.result)
     val lexer = new FIRRTLLexer(antlrStream)
@@ -56,7 +56,7 @@ object Parser extends LazyLogging
     val numSyntaxErrors = parser.getNumberOfSyntaxErrors
     if (numSyntaxErrors > 0) throw new ParserException(s"${numSyntaxErrors} syntax error(s) detected")
 
-    val visitor = new Visitor(filename, useInfo) 
+    val visitor = new Visitor(infoMode)
     val ast = time("Visitor") { visitor.visit(cst) } match {
       case c: Circuit => c
       case x => throw new ClassCastException("Error! AST not rooted with Circuit node!")
@@ -65,6 +65,11 @@ object Parser extends LazyLogging
     ast
   }
 
-  def parse(lines: Seq[String]): Circuit = parse("<None>", lines.iterator)
+  def parse(lines: Seq[String]): Circuit = parse(lines.iterator)
 
+  sealed abstract class InfoMode
+  case object IgnoreInfo extends InfoMode
+  case object UseInfo extends InfoMode
+  case class GenInfo(filename: String) extends InfoMode
+  case class AppendInfo(filename: String) extends InfoMode
 }

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -677,7 +677,7 @@ object CheckGenders extends Pass {
    }
 }
 
-object CheckWidths extends Pass with StanzaPass {
+object CheckWidths extends Pass {
    def name = "Width Check"
    var mname = ""
    class UninferredWidth (info:Info) extends PassException(s"${info} : [module ${mname}]  Uninferred width.")

--- a/src/test/scala/firrtlTests/CheckInitializationSpec.scala
+++ b/src/test/scala/firrtlTests/CheckInitializationSpec.scala
@@ -31,10 +31,11 @@ import java.io._
 import org.scalatest._
 import org.scalatest.prop._
 import firrtl._
+import firrtl.Parser.IgnoreInfo
 import firrtl.passes._
 
 class CheckInitializationSpec extends FirrtlFlatSpec {
-  private def parse(input: String) = Parser.parse("", input.split("\n").toIterator, false)
+  private def parse(input: String) = Parser.parse(input.split("\n").toIterator, IgnoreInfo)
   private val passes = Seq(
      ToWorkingIR,
      CheckHighForm,

--- a/src/test/scala/firrtlTests/CheckSpec.scala
+++ b/src/test/scala/firrtlTests/CheckSpec.scala
@@ -20,7 +20,7 @@ class CheckSpec extends FlatSpec with Matchers {
         |      read-latency => 0
         |      write-latency => 1""".stripMargin
     intercept[PassExceptions] {
-      passes.foldLeft(Parser.parse("",input.split("\n").toIterator)) {
+      passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
         (c: Circuit, p: Pass) => p.run(c)
       }
     }

--- a/src/test/scala/firrtlTests/ChirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlSpec.scala
@@ -67,7 +67,7 @@ class ChirrtlSpec extends FirrtlFlatSpec {
        |      infer mport y = ram[UInt(4)], newClock
        |      y <= UInt(5)
        """.stripMargin
-    passes.foldLeft(Parser.parse("",input.split("\n").toIterator)) {
+    passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
       (c: Circuit, p: Pass) => p.run(c)
     }
   }

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -3,6 +3,7 @@ package firrtlTests
 import org.scalatest.Matchers
 import java.io.{StringWriter,Writer}
 import firrtl._
+import firrtl.Parser.IgnoreInfo
 import firrtl.passes._
 
 // Tests the following cases for constant propagation:
@@ -20,7 +21,7 @@ class ConstantPropagationSpec extends FirrtlFlatSpec {
       ResolveGenders,
       InferWidths,
       ConstProp)
-  def parse(input: String): Circuit = Parser.parse("", input.split("\n").toIterator, false)
+  def parse(input: String): Circuit = Parser.parse(input.split("\n").toIterator, IgnoreInfo)
   private def exec (input: String) = {
     passes.foldLeft(parse(input)) {
       (c: Circuit, p: Pass) => p.run(c)

--- a/src/test/scala/firrtlTests/LowerTypesSpec.scala
+++ b/src/test/scala/firrtlTests/LowerTypesSpec.scala
@@ -32,7 +32,7 @@ class LowerTypesSpec extends FirrtlFlatSpec {
     LowerTypes)
 
   private def executeTest(input: String, expected: Seq[String]) = {
-    val c = passes.foldLeft(Parser.parse("", input.split("\n").toIterator)) {
+    val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
       (c: Circuit, p: Pass) => p.run(c)
     }
     val lines = c.serialize.split("\n") map normalized

--- a/src/test/scala/firrtlTests/UniquifySpec.scala
+++ b/src/test/scala/firrtlTests/UniquifySpec.scala
@@ -44,7 +44,7 @@ class UniquifySpec extends FirrtlFlatSpec {
   )
 
   private def executeTest(input: String, expected: Seq[String]) = {
-    val c = passes.foldLeft(Parser.parse("", input.split("\n").toIterator)) {
+    val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
       (c: Circuit, p: Pass) => p.run(c)
     }
     val lines = c.serialize.split("\n") map normalized

--- a/src/test/scala/firrtlTests/UnitTests.scala
+++ b/src/test/scala/firrtlTests/UnitTests.scala
@@ -32,11 +32,12 @@ import org.scalatest._
 import org.scalatest.prop._
 import firrtl._
 import firrtl.passes._
+import firrtl.Parser.IgnoreInfo
 
 class UnitTests extends FirrtlFlatSpec {
-  def parse (input:String) = Parser.parse("",input.split("\n").toIterator,false)
+  def parse (input:String) = Parser.parse(input.split("\n").toIterator, IgnoreInfo)
   private def executeTest(input: String, expected: Seq[String], passes: Seq[Pass]) = {
-    val c = passes.foldLeft(Parser.parse("", input.split("\n").toIterator)) {
+    val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
       (c: Circuit, p: Pass) => p.run(c)
     }
     val lines = c.serialize.split("\n") map normalized
@@ -132,7 +133,7 @@ class UnitTests extends FirrtlFlatSpec {
       ToWorkingIR,
       InferTypes)
     intercept[PassException] {
-      val c = Parser.parse("",splitExpTestCode.split("\n").toIterator)
+      val c = Parser.parse(splitExpTestCode.split("\n").toIterator)
       val c2 = passes.foldLeft(c)((c, p) => p run c)
       new VerilogEmitter().run(c2, new OutputStreamWriter(new ByteArrayOutputStream))
     }
@@ -143,7 +144,7 @@ class UnitTests extends FirrtlFlatSpec {
       ToWorkingIR,
       SplitExpressions,
       InferTypes)
-    val c = Parser.parse("",splitExpTestCode.split("\n").toIterator)
+    val c = Parser.parse(splitExpTestCode.split("\n").toIterator)
     val c2 = passes.foldLeft(c)((c, p) => p run c)
     new VerilogEmitter().run(c2, new OutputStreamWriter(new ByteArrayOutputStream))
   }


### PR DESCRIPTION
Replacement for #158 and related to ucb-bar/chisel3#186

This is a mostly fully functional implementation of file info/source locators in the FIRRTL compiler.
Because of difficulty in implementation, single line scopes are disallowed for everything except register resets (no single line scoping is used except register reset). This implementation requires that the source locators (if available) come at the end of the line, except registers where it must come after the reset definition (if there is one).

The Parser now supports 4 FileInfo options:    

1. IgnoreInfo - populate all nodes with NoInfo (even if info is provided in the firrtl code)    
1. UseInfo - populate nodes with any source locators provided in the firrtl code    
1. GenInfo - generate source locators from the firrtl code file itself    
1. AppendInfo - append GenInfo results to the end of parsed UseInfo    

The one big thing that needs some work is that the file info text itself is handled similarly to how StringLits are handled for Printf. This means that it doesn't really support escaped close bracket the way it should (instead supporting escaped double quotes because it thinks it's a double quoted string). Fixing this requires some refactoring of the StringLiteral handling that seems less important than getting this PR out asap. 