### PR TITLE
Fix non-thread safe Serialize by splitting it into class and object

### DIFF
--- a/src/main/scala/firrtl/Serialize.scala
+++ b/src/main/scala/firrtl/Serialize.scala
@@ -31,25 +31,29 @@ import firrtl.PrimOps._
 import firrtl.Utils._
 
 private object Serialize {
-
   def serialize(root: AST): String = {
+    lazy val ser = new Serialize
     root match {
-      case r: PrimOp => serialize(r)
-      case r: Expression => serialize(r)
-      case r: Stmt => serialize(r)
-      case r: Width => serialize(r)
-      case r: Flip => serialize(r)
-      case r: Field => serialize(r)
-      case r: Type => serialize(r)
-      case r: Direction => serialize(r)
-      case r: Port => serialize(r)
-      case r: Module => serialize(r)
-      case r: Circuit => serialize(r)
-      case r: StringLit => serialize(r)
+      case r: PrimOp => ser.serialize(r)
+      case r: Expression => ser.serialize(r)
+      case r: Stmt => ser.serialize(r)
+      case r: Width => ser.serialize(r)
+      case r: Flip => ser.serialize(r)
+      case r: Field => ser.serialize(r)
+      case r: Type => ser.serialize(r)
+      case r: Direction => ser.serialize(r)
+      case r: Port => ser.serialize(r)
+      case r: Module => ser.serialize(r)
+      case r: Circuit => ser.serialize(r)
+      case r: StringLit => ser.serialize(r)
       case _ => throw new Exception("serialize called on unknown AST node!")
     }
   }
+  /** Creates new instance of Serialize */
+  def apply() = new Serialize
+}
 
+class Serialize {
   def serialize(bi: BigInt): String =
     if (bi < BigInt(0)) "\"h" + bi.toString(16).substring(1) + "\""
     else "\"h" + bi.toString(16) + "\""

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -681,7 +681,9 @@ object CheckWidths extends Pass {
    def name = "Width Check"
    var mname = ""
    class UninferredWidth (info:Info) extends PassException(s"${info} : [module ${mname}]  Uninferred width.")
-   class WidthTooSmall (info:Info,v:String) extends PassException(s"${info} : [module ${mname}  Width too small for constant ${v}.")
+   class WidthTooSmall(info: Info, b: BigInt) extends PassException(
+         s"$info : [module $mname]  Width too small for constant " +
+         Serialize().serialize(b) + ".")
    class NegWidthException(info:Info) extends PassException(s"${info}: [module ${mname}] Width cannot be negative or zero.")
    def run (c:Circuit): Circuit = {
       val errors = new Errors()
@@ -699,7 +701,7 @@ object CheckWidths extends Pass {
                   (e.width) match { 
                      case (w:IntWidth) => 
                         if (scala.math.max(1,e.value.bitLength) > w.width) {
-                           errors.append(new WidthTooSmall(info, serialize(e.value)))
+                           errors.append(new WidthTooSmall(info, e.value))
                         }
                      case (w) => errors.append(new UninferredWidth(info))
                   }
@@ -708,7 +710,7 @@ object CheckWidths extends Pass {
                case (e:SIntValue) => {
                   (e.width) match { 
                      case (w:IntWidth) => 
-                        if (e.value.bitLength + 1 > w.width) errors.append(new WidthTooSmall(info, serialize(e.value)))
+                        if (e.value.bitLength + 1 > w.width) errors.append(new WidthTooSmall(info, e.value))
                      case (w) => errors.append(new UninferredWidth(info))
                   }
                   check_width_w(info)(e.width)


### PR DESCRIPTION
As far as I can tell this fixes the non-thread safe behavior we've been seeing.

It is kind of awkward that the BigInt serialize function is part of Serialize since this function is really for nodes of the FIRRTL AST. You can see in Checks.scala that calling it requires (new Serialize).serialize which is kind of awkward, perhaps this function should be replaced with a Utils function called prettyPrint or something?

Resolves #181 
Fixes #159 ?