### PR TITLE
InferWidths now only fixes declaration widths

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -111,9 +111,9 @@ class HighFirrtlToMiddleFirrtl () extends Transform with SimpleRun {
       passes.ConstProp,
       passes.ResolveKinds,
       passes.InferTypes,
-      passes.ResolveGenders)
-      //passes.InferWidths,
-      //passes.CheckWidths)
+      passes.ResolveGenders,
+      passes.InferWidths,
+      passes.CheckWidths)
    def execute (circuit: Circuit, annotationMap: AnnotationMap): TransformResult =
       run(circuit, passSeq)
 }

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -74,6 +74,9 @@ object Utils extends LazyLogging {
    implicit def toWrappedExpression (x:Expression) = new WrappedExpression(x)
    def ceil_log2(x: BigInt): BigInt = (x-1).bitLength
    def ceil_log2(x: Int): Int = scala.math.ceil(scala.math.log(x) / scala.math.log(2)).toInt
+   def max(a: BigInt, b: BigInt): BigInt = if (a >= b) a else b
+   def min(a: BigInt, b: BigInt): BigInt = if (a >= b) b else a
+   def pow_minus_one(a: BigInt, b: BigInt): BigInt = a.pow(b.toInt) - 1
    val gen_names = Map[String,Int]()
    val delin = "_"
    val BoolType = UIntType(IntWidth(1))


### PR DESCRIPTION
Then calls InferTypes to propagate inferred widths to expressions.
Required upgrading InferTypes to do simple width propagation.
Fixes #206  and #200.