### PR TITLE
remove ConstProp in HighFirrtlToMiddleFirrtl

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -108,7 +108,6 @@ class HighFirrtlToMiddleFirrtl () extends Transform with SimpleRun {
       passes.RemoveAccesses,
       passes.ExpandWhens,
       passes.CheckInitialization,
-      passes.ConstProp,
       passes.ResolveKinds,
       passes.InferTypes,
       passes.ResolveGenders,


### PR DESCRIPTION
ConstProp before width padding causes errors for SIntLiteral. Any reason to add it here?