### PR TITLE
Change default log level to warn

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -30,7 +30,7 @@ MODIFICATIONS.
             <pattern>[%-4level] %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="info">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
On log level info, the compiler prints at the start and end of each pass as well as the timing information. This is somewhat helpful for an individual but blows up the Travis logs (making them unreadable). Ideally users could change log-level with a command-line option or similar, but I don't have time to figure out how to do that right now.