### PR TITLE
Fix use of global state in instance loop checking

### DIFF
--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -256,7 +256,7 @@ object CheckHighForm extends Pass with LazyLogging {
             if (!c.modules.map(_.name).contains(s.module))
               errors.append(new ModuleNotDefinedException(s.module))
             // Check to see if a recursive module instantiation has occured
-            val childToParent = moduleGraph.add(mname, s.module)
+            val childToParent = moduleGraph.add(m.name, s.module)
             if(childToParent.nonEmpty) {
               errors.append(new InstanceLoop(childToParent.mkString("->")))
             }

--- a/src/test/scala/firrtlTests/MultiThreadingSpec.scala
+++ b/src/test/scala/firrtlTests/MultiThreadingSpec.scala
@@ -22,7 +22,7 @@ class MultiThreadingSpec extends FirrtlPropSpec {
       new firrtl.LowFirrtlCompiler,
       new firrtl.VerilogCompiler)
     val inputFilePath = s"/integration/GCDTester.fir" // arbitrary
-    val numThreads = 8 // arbitrary
+    val numThreads = 64 // arbitrary
 
     // Begin the actual test
     val inputStream = getClass().getResourceAsStream(inputFilePath)


### PR DESCRIPTION
Also increase sensitivity of thread safety checking
Fixes #159 