### PR TITLE
Added RemoveEmpty.scala, which removes Empty and nested Blocks

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -62,6 +62,20 @@ object Utils extends LazyLogging {
     result
   }
 
+  /** Removes all [[firrtl.ir.Empty]] statements and condenses
+   * [[firrtl.ir.Block]] statements.
+    */
+  def squashEmpty(s: Statement): Statement = s map squashEmpty match {
+    case Block(stmts) =>
+      val newStmts = stmts filter (_ != EmptyStmt)
+      newStmts.size match {
+        case 0 => EmptyStmt
+        case 1 => newStmts.head
+        case _ => Block(newStmts)
+      }
+    case s => s
+  }
+
   /** Indent the results of [[ir.FirrtlNode.serialize]] */
   def indent(str: String) = str replaceAllLiterally ("\n", "\n  ")
   def serialize(bi: BigInt): String =

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -71,18 +71,6 @@ object ExpandWhens extends Pass {
     }
     expsx
   }
-  private def squashEmpty(s: Statement): Statement = {
-    s map squashEmpty match {
-      case Block(stmts) =>
-        val newStmts = stmts filter (_ != EmptyStmt)
-        newStmts.size match {
-          case 0 => EmptyStmt
-          case 1 => newStmts.head
-          case _ => Block(newStmts)
-        }
-      case s => s
-    }
-  }
   private def expandNetlist(netlist: LinkedHashMap[WrappedExpression, Expression]) =
     netlist map { case (k, v) =>
       v match {

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -179,7 +179,7 @@ object ExpandWhens extends Pass {
         case m: ExtModule => m
         case m: Module =>
         val (netlist, simlist, bodyx) = expandWhens(m)
-        val newBody = Block(Seq(bodyx map squashEmpty) ++ expandNetlist(netlist) ++ simlist)
+        val newBody = Block(Seq(squashEmpty(bodyx)) ++ expandNetlist(netlist) ++ simlist)
         Module(m.info, m.name, m.ports, newBody)
       }
     }

--- a/src/main/scala/firrtl/passes/RemoveEmpty.scala
+++ b/src/main/scala/firrtl/passes/RemoveEmpty.scala
@@ -8,24 +8,8 @@ import firrtl.ir._
 object RemoveEmpty extends Pass {
   def name = "Remove Empty Statements"
   private def onModule(m: DefModule): DefModule = {
-    def onScope(s: Statement): Statement = {
-      val newStmts = mutable.ArrayBuffer[Statement]()
-      def onStmt(s: Statement): Unit = s match {
-        case EmptyStmt => 
-        case Block(stmts) => 
-          stmts.foreach(onStmt(_))
-        case c: Conditionally => c map onScope
-        case s => newStmts += s
-      }
-      s match {
-        case Block(stmts) =>
-          stmts.foreach(onStmt(_))
-          Block(newStmts.toSeq)
-        case s => s map onScope
-      }
-    }
     m match {
-      case m: Module => Module(m.info, m.name, m.ports, onScope(m.body))
+      case m: Module => Module(m.info, m.name, m.ports, Utils.squashEmpty(m.body))
       case m: ExtModule => m
     }
   }

--- a/src/main/scala/firrtl/passes/RemoveEmpty.scala
+++ b/src/main/scala/firrtl/passes/RemoveEmpty.scala
@@ -1,0 +1,35 @@
+package firrtl
+package passes
+
+import scala.collection.mutable
+import firrtl.Mappers.{ExpMap, StmtMap}
+import firrtl.ir._
+
+object RemoveEmpty extends Pass {
+  def name = "Remove Empty Statements"
+  private def onModule(m: DefModule): DefModule = {
+    def onScope(s: Statement): Statement = {
+      val newStmts = mutable.ArrayBuffer[Statement]()
+      def onStmt(s: Statement): Unit = s match {
+        case EmptyStmt => 
+        case Block(stmts) => 
+          stmts.foreach(onStmt(_))
+        case c: Conditionally => c map onScope
+        case s => newStmts += s
+      }
+      s match {
+        case Block(stmts) =>
+          stmts.foreach(onStmt(_))
+          Block(newStmts.toSeq)
+        case s => s map onScope
+      }
+    }
+    m match {
+      case m: Module => Module(m.info, m.name, m.ports, onScope(m.body))
+      case m: ExtModule => m
+    }
+  }
+  def run(c: Circuit): Circuit = Circuit(c.info, c.modules.map(onModule _), c.main)
+}
+
+// vim: set ts=4 sw=4 et:


### PR DESCRIPTION
A utility pass other Firrtl compilers can use. Also makes testing easier because you can remove Empty statements that may be introduced via your compiler pass (but you don't want to have them in the check string).