### PR TITLE
provide parser for naive string

### DIFF
--- a/src/main/scala/firrtl/Parser.scala
+++ b/src/main/scala/firrtl/Parser.scala
@@ -82,6 +82,8 @@ object Parser extends LazyLogging {
 
   def parse(lines: Seq[String]): Circuit = parse(lines.iterator)
 
+  def parse(text: String): Circuit = parse(text split "\n")
+
   sealed abstract class InfoMode
 
   case object IgnoreInfo extends InfoMode


### PR DESCRIPTION
I'm sick of writing `split "\n"`