### PR TITLE
Add missing case for connecting ClockType

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -390,6 +390,7 @@ object Utils extends LazyLogging {
             }
             points
          }
+        case (ClockType,ClockType) => if (flip1 == flip2) Seq((0, 0)) else Seq()
       }
    }
 // =========== GENDER/FLIP UTILS ============


### PR DESCRIPTION
This case is exercised if you assign one ClockType signal from another.