### PR TITLE
Changed Chirrtl pass for write mask

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -133,7 +133,11 @@ object ExpandWhens extends Pass {
                     case (WInvalid(), WInvalid()) => WInvalid()
                     case (WInvalid(), fv) => ValidIf(NOT(s.pred), fv, tpe(fv))
                     case (tv, WInvalid()) => ValidIf(s.pred, tv, tpe(tv))
-                    case (tv, fv) => Mux(s.pred, tv, fv, mux_type_and_widths(tv, fv))
+                    case (tv, fv) => {
+                      // parameterization might result in the same tv, fv -- get rid of unnecessary mux
+                      if (tv != fv) Mux(s.pred, tv, fv, mux_type_and_widths(tv, fv))
+                      else tv
+                    }
                   }
                 case None =>
                   // Since not in netlist, lvalue must be declared in EXACTLY one of conseq or alt

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -1131,11 +1131,18 @@ object RemoveCHIRRTL extends Pass {
                      }}
                   def set_write (vec:Seq[MPort],data:String,mask:String) : Unit = {
                      val tmask = create_mask(s.tpe)
+                     // mem data type = ground type implies no masking used (per Chisel spec)
+                     val maskInitVal = tmask match {
+                        case BoolType => one
+                        case _ => zero
+                     }
                      for (r <- vec ) {
                         stmts += IsInvalid(s.info,SubField(SubField(Reference(s.name,ut),r.name,ut),data,tdata))
                         for (x <- create_exps(SubField(SubField(Reference(s.name,ut),r.name,ut),mask,tmask)) ) {
-                           stmts += Connect(s.info,x,zero)
-                        }}}
+                           stmts += Connect(s.info,x,maskInitVal)
+                        }
+                     }
+                  }
                   val rds = (hash.getOrElse(s.name,EMPs())).readers
                   set_poison(rds,"addr")
                   set_enable(rds,"en")


### PR DESCRIPTION
* If the memory datatype is not a ground type, write mask is initialized to 1.
    Chisel only allows write masks that are Vecs of Bools IF the Chisel memory
    type is a Vec of x. To reduce the # of extraneous nodes, the generated
    Firrtl/Verilog (from Chirrtl) should have a constant 1 connected to the mask.
* Changed ExpandWhens s.t. if a Mux is to be generated where the true value ==
    false value, skip generating the Mux and propagate the tv directly. (Simplifies
    the node graph earlier on when Chisel designs are parameterized).