### PR TITLE
Bugfix: ExpandWhen was emitting WInvalid() 

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -137,15 +137,20 @@ object ExpandWhens extends Pass {
                 conseqNetlist getOrElse (lvalue, altNetlist(lvalue))
             }
 
-            nodes get res match {
-              case Some(name) =>
-                netlist(lvalue) = WRef(name, res.tpe, NodeKind(), MALE)
+            res match {
+              case _: ValidIf | _: Mux | _: DoPrim => nodes get res match {
+                case Some(name) =>
+                  netlist(lvalue) = WRef(name, res.tpe, NodeKind(), MALE)
+                  EmptyStmt
+                case None =>
+                  val name = namespace.newTemp
+                  nodes(res) = name
+                  netlist(lvalue) = WRef(name, res.tpe, NodeKind(), MALE)
+                  DefNode(s.info, name, res)
+              }
+              case _ =>
+                netlist(lvalue) = res
                 EmptyStmt
-              case None =>
-                val name = namespace.newTemp
-                nodes(res) = name
-                netlist(lvalue) = WRef(name, res.tpe, NodeKind(), MALE)
-                DefNode(s.info, name, res)
             }
           }
           Block(Seq(conseqStmt, altStmt) ++ memos)

--- a/src/test/scala/firrtlTests/ExpandWhensSpec.scala
+++ b/src/test/scala/firrtlTests/ExpandWhensSpec.scala
@@ -32,9 +32,51 @@ import org.scalatest._
 import org.scalatest.prop._
 import firrtl._
 import firrtl.passes._
+import firrtl.ir._
+import firrtl.Parser.IgnoreInfo
 
 class ExpandWhensSpec extends FirrtlFlatSpec {
+  private def parse(input: String) = Parser.parse(input.split("\n").toIterator, IgnoreInfo)
+  private def executeTest(input: String, notExpected: String, passes: Seq[Pass]) = {
+    val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
+      (c: Circuit, p: Pass) => p.run(c)
+    }
+    val lines = c.serialize.split("\n") map normalized
+
+    lines foreach { l =>
+      l.contains(notExpected) should be (false)
+    }
+  }
   "Expand Whens" should "compile and run" in {
     runFirrtlTest("ExpandWhens", "/passes/ExpandWhens")
+  }
+  "Expand Whens" should "not emit INVALID" in {
+    val passes = Seq(
+      ToWorkingIR,
+      CheckHighForm,
+      ResolveKinds,
+      InferTypes,
+      CheckTypes,
+      Uniquify,
+      ResolveKinds,
+      InferTypes,
+      ResolveGenders,
+      CheckGenders,
+      InferWidths,
+      CheckWidths,
+      PullMuxes,
+      ExpandConnects,
+      RemoveAccesses,
+      ExpandWhens)
+    val input =
+  """|circuit Tester : 
+     |  module Tester :
+     |    input p : UInt<1>
+     |    when p :
+     |      wire a : {b : UInt<64>, c : UInt<64>}
+     |      a is invalid
+     |      a.b <= UInt<64>("h04000000000000000")""".stripMargin
+    val check = "INVALID"
+    executeTest(input, check, passes)
   }
 }


### PR DESCRIPTION
In the case that a bundle-typed wire declared and partially assigned within a when statement, the following generated node could be created:
```
node GEN = INVALID
```

Fix entails looking at the expression before memoizing - if its a referencing expression, we don't memoize. Otherwise, we do.