### PR TITLE
Transform for blackboxing memories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.6" % "test"
 
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
 
+libraryDependencies += "net.jcazevedo" %% "moultingyaml" % "0.2"
+
 // Assembly
 
 assemblyJarName in assembly := "firrtl.jar"

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -58,7 +58,7 @@ Optional Arguments:
   --inferRW <circuit>            Enable readwrite port inference for the target circuit
   --inline <module>|<instance>   Inline a module (e.g. "MyModule") or instance (e.g. "MyModule.myinstance")
 
-  --replSeqMem -c:<circuit>:-i<filename>:-o<filename> 
+  --replSeqMem -c:<circuit>:-i:<filename>:-o:<filename> 
   *** Replace sequential memories with blackboxes + configuration file
   *** Input configuration file optional
   *** Note: sub-arguments to --replSeqMem should be delimited by : and not white space!

--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -57,6 +57,12 @@ Optional Arguments:
                                  Supported modes: ignore, use, gen, append
   --inferRW <circuit>            Enable readwrite port inference for the target circuit
   --inline <module>|<instance>   Inline a module (e.g. "MyModule") or instance (e.g. "MyModule.myinstance")
+
+  --replSeqMem -c:<circuit>:-i<filename>:-o<filename> 
+  *** Replace sequential memories with blackboxes + configuration file
+  *** Input configuration file optional
+  *** Note: sub-arguments to --replSeqMem should be delimited by : and not white space!
+  
   [--help|-h]                    Print usage string
 """
 
@@ -74,12 +80,16 @@ Optional Arguments:
     def handleInferRWOption(value: String) = 
       passes.InferReadWriteAnnotation(value, TransID(-1))
 
+    def handleReplSeqMem(value: String) = 
+      passes.ReplSeqMemAnnotation(value, TransID(-2))
+
     run(args: Array[String],
       Map( "high" -> new HighFirrtlCompiler(),
         "low" -> new LowFirrtlCompiler(),
         "verilog" -> new VerilogCompiler()),
       Map("--inline" -> handleInlineOption _,
-          "--inferRW" -> handleInferRWOption _),
+          "--inferRW" -> handleInferRWOption _,
+          "--replSeqMem" -> handleReplSeqMem _),
       usage
     )
   }

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -189,6 +189,7 @@ class LowFirrtlCompiler extends Compiler {
       new ResolveAndCheck(),
       new HighFirrtlToMiddleFirrtl(),
       new passes.InferReadWrite(TransID(-1)),
+      new passes.ReplSeqMem(TransID(-2)),
       new MiddleFirrtlToLowFirrtl(),
       new EmitFirrtl(writer)
    )
@@ -202,6 +203,7 @@ class VerilogCompiler extends Compiler {
       new ResolveAndCheck(),
       new HighFirrtlToMiddleFirrtl(),
       new passes.InferReadWrite(TransID(-1)),
+      new passes.ReplSeqMem(TransID(-2)),
       new MiddleFirrtlToLowFirrtl(),
       new passes.InlineInstances(TransID(0)),
       new EmitVerilogFromLowFirrtl(writer)

--- a/src/main/scala/firrtl/Namespace.scala
+++ b/src/main/scala/firrtl/Namespace.scala
@@ -85,7 +85,7 @@ object Namespace {
     namespace
   }
 
-  /** Initializes a [[Namespace]] for [[Module]] names in a [[Circuit]] */
+  /** Initializes a [[Namespace]] for [[ir.Module]] names in a [[ir.Circuit]] */
   def apply(c: Circuit): Namespace = {
     val namespace = new Namespace
     c.modules foreach { m =>

--- a/src/main/scala/firrtl/Namespace.scala
+++ b/src/main/scala/firrtl/Namespace.scala
@@ -84,5 +84,14 @@ object Namespace {
 
     namespace
   }
+
+  /** Initializes a [[Namespace]] for [[Module]] names in a [[Circuit]] */
+  def apply(c: Circuit): Namespace = {
+    val namespace = new Namespace
+    c.modules foreach { m =>
+      namespace.namespace += m.name
+    }
+    namespace
+  }
 }
 

--- a/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
@@ -1,0 +1,130 @@
+package firrtl.passes
+
+import scala.collection.mutable.{ArrayBuffer,HashMap}
+import AnalysisUtils._
+import firrtl.WrappedExpression._
+import firrtl.ir._
+import firrtl._
+import firrtl.Utils._
+
+case class AppendableInfo(fields: Map[String,Any]) extends Info {
+  def append(a: Map[String,Any]) = this.copy(fields = fields ++ a)
+  def append(a: Tuple2[String,Any]): AppendableInfo = append(Map(a))
+  def get(f: String) = fields.get(f)
+  override def equals(b: Any) = b match {
+    case i: AppendableInfo => fields - "info" == i.fields - "info"
+    case _ => false
+  }
+}
+
+object AnalysisUtils {
+
+  def getConnects(m: Module) = {
+    val connects = HashMap[String, Expression]()
+    def getConnects(s: Statement): Unit = s match {
+      case s: Connect  =>
+        connects(s.loc.serialize) = s.expr
+      case s: PartialConnect =>
+        connects(s.loc.serialize) = s.expr
+      case s: DefNode =>
+        connects(s.name) = s.value
+      case s: Block =>
+        s.stmts foreach getConnects
+      case _ =>
+    }
+    getConnects(m.body)
+    connects.toMap
+  }  
+
+  // only works in a module
+  def getConnectOrigin(connects: Map[String, Expression], node: String): Expression = 
+    if (connects contains node) getConnectOrigin(connects,connects(node))
+    else EmptyExpression
+  
+  // backward searches until PrimOp, Lit or non-trivial Mux appears
+  private def getConnectOrigin(connects: Map[String, Expression], e: Expression): Expression = e match {    
+    case Mux(cond, tv, fv, _) if we(tv) == we(one) && we(fv) == we(zero) =>
+      getConnectOrigin(connects,cond.serialize)
+    case _: WRef | _: SubField | _: SubIndex | _: SubAccess if connects contains e.serialize =>
+      getConnectOrigin(connects,e.serialize) 
+    case _ => e
+  }
+
+  def appendInfo[T <: Info](info: T, add: Map[String,Any]) = info match {
+    case i: AppendableInfo => i.append(add)
+    case _ => AppendableInfo(fields = add + ("info" -> info))
+  }
+  def appendInfo[T <: Info](info: T, add: Tuple2[String,Any]): AppendableInfo = appendInfo(info,Map(add))
+  def getInfo[T <: Info](info: T, k: String) = info match{
+    case i: AppendableInfo => i.get(k)
+    case _ => None
+  }
+  def containsInfo[T <: Info](info: T, k: String) = info match {
+    case i: AppendableInfo => i.fields.contains(k)
+    case _ => false
+  }
+
+  def eqMems(a: DefMemory, b: DefMemory) = {
+    a.info == b.info &&
+    a.dataType == b.dataType &&
+    a.depth == b.depth &&
+    a.writeLatency == b.writeLatency &&
+    a.readLatency == b.readLatency &&
+    a.readers == b.readers &&
+    a.writers == b.writers &&
+    a.readwriters == b.readwriters &&
+    a.readUnderWrite == b.readUnderWrite
+  }  
+
+}
+
+object AnnotateMemMacros extends Pass {
+
+  def name = "Analyze sequential memories and tag with info for future passes (useMacro,maskGran)"
+
+  def run(c: Circuit) = {
+
+    def annotateModMems(m: Module) = {
+      val connects = getConnects(m)
+
+      // returns # of mask bits if used
+      def getMaskBits(wen: String, wmask: String): Option[Int] = {
+        val wenOrigin = we(getConnectOrigin(connects,wen))
+        val one1 = we(one)
+        val wmaskOrigin = connects.keys.toSeq.filter(_.startsWith(wmask)).map(x => we(getConnectOrigin(connects,x)))
+        // all wmask bits are equal to wmode/wen or all wmask bits = 1(for redundancy checking)
+        val redundantMask = wmaskOrigin.map( x => (x == wenOrigin) || (x == one1) ).foldLeft(true)(_ && _)
+        if (redundantMask) None else Some(wmaskOrigin.length)
+      }
+
+      def updateStmts(s: Statement): Statement = s match {
+        // only annotate memories that are candidates for memory macro replacements
+        // i.e. rw, w + r (read,write 1 cycle delay)
+        case m: DefMemory if m.readLatency == 1 && m.writeLatency == 1 && 
+            (m.writers.length + m.readwriters.length) == 1 && m.readers.length <= 1 =>
+          val dataBits = bitWidth(m.dataType)
+          val rwMasks = m.readwriters map (w => getMaskBits(s"${m.name}.$w.wmode",s"${m.name}.$w.wmask"))
+          val wMasks = m.writers map (w => getMaskBits(s"${m.name}.$w.en",s"${m.name}.$w.mask"))
+          val maskBits = (rwMasks ++ wMasks).head
+          val memAnnotations = Map("useMacro" -> true)
+          val tempInfo = appendInfo(m.info,memAnnotations)
+          if (maskBits == None) m.copy(info = tempInfo)
+          else m.copy(info = tempInfo.append("maskGran" -> dataBits/maskBits.get))       
+        case b: Block => Block(b.stmts map updateStmts)
+        case s => s
+      }
+
+      m.copy(body=updateStmts(m.body))
+    } 
+
+    val updatedMods = c.modules map {
+      case m: Module => annotateModMems(m)
+      case m: ExtModule => m
+    }
+    c.copy(modules = updatedMods)
+
+  }  
+
+}
+
+// TODO: Add floorplan info?

--- a/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
@@ -9,7 +9,7 @@ import firrtl.Utils._
 
 case class AppendableInfo(fields: Map[String,Any]) extends Info {
   def append(a: Map[String,Any]) = this.copy(fields = fields ++ a)
-  def append(a: Tuple2[String,Any]): AppendableInfo = append(Map(a))
+  def append(a: (String,Any)): AppendableInfo = append(Map(a))
   def get(f: String) = fields.get(f)
   override def equals(b: Any) = b match {
     case i: AppendableInfo => fields - "info" == i.fields - "info"
@@ -89,7 +89,7 @@ object AnalysisUtils {
     case i: AppendableInfo => i.append(add)
     case _ => AppendableInfo(fields = add + ("info" -> info))
   }
-  def appendInfo[T <: Info](info: T, add: Tuple2[String,Any]): AppendableInfo = appendInfo(info,Map(add))
+  def appendInfo[T <: Info](info: T, add: (String,Any)): AppendableInfo = appendInfo(info,Map(add))
   def getInfo[T <: Info](info: T, k: String) = info match{
     case i: AppendableInfo => i.get(k)
     case _ => None

--- a/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
@@ -1,6 +1,8 @@
+// See LICENSE for license details.
+
 package firrtl.passes
 
-import scala.collection.mutable.{ArrayBuffer,HashMap}
+import scala.collection._
 import AnalysisUtils._
 import firrtl.WrappedExpression._
 import firrtl.ir._
@@ -8,9 +10,9 @@ import firrtl._
 import firrtl.Utils._
 import firrtl.Mappers._
 
-case class AppendableInfo(fields: Map[String,Any]) extends Info {
-  def append(a: Map[String,Any]) = this.copy(fields = fields ++ a)
-  def append(a: (String,Any)): AppendableInfo = append(Map(a))
+case class AppendableInfo(fields: Map[String, Any]) extends Info {
+  def append(a: Map[String, Any]) = this.copy(fields = fields ++ a)
+  def append(a: (String, Any)): AppendableInfo = append(Map(a))
   def get(f: String) = fields.get(f)
   override def equals(b: Any) = b match {
     case i: AppendableInfo => fields - "info" == i.fields - "info"
@@ -21,50 +23,37 @@ case class AppendableInfo(fields: Map[String,Any]) extends Info {
 object AnalysisUtils {
 
   def getConnects(m: Module) = {
-    val connects = HashMap[String, Expression]()
-    def getConnects(s: Statement): Unit = s match {
-      case s: Connect =>
-        connects(s.loc.serialize) = s.expr
-      case s: DefNode =>
-        connects(s.name) = s.value
-      case s: Block =>
-        s.stmts foreach getConnects
-      case _ =>
+    val connects = mutable.HashMap[String, Expression]()
+    def getConnects(s: Statement): Statement = {
+      s map getConnects match {
+        case Connect(_, loc, expr) =>
+          connects(loc.serialize) = expr
+        case DefNode(_, name, value) =>
+          connects(name) = value
+        case _ => // do nothing
+      }
+      s // return because we only have map and not foreach
     }
     getConnects(m.body)
     connects.toMap
   }  
 
-  // only works in a module
+  // takes in a list of node-to-node connections in a given module and looks to find the origin of the LHS.
+  // if the source is a trivial primop/mux, etc. that has yet to be optimized via constant propagation,
+  // the function will try to search backwards past the primop/mux. 
+  // use case: compare if two nodes have the same origin
+  // limitation: only works in a module (stops @ module inputs)
+  // TODO: more thorough (i.e. a + 0 = a)
   def getConnectOrigin(connects: Map[String, Expression], node: String): Expression = {
-    if (connects contains node) getConnectOrigin(connects,connects(node))
+    if (connects contains node) getOrigin(connects, connects(node))
     else EmptyExpression
   }
 
-  def checkLit(e: Expression) = e match {
-    case l : Literal => true
-    case _ => false
-  }
-
-  def getOrigin(connects: Map[String, Expression], e: Expression) = e match {
-    case DoPrim(_,_,_,_) => getConnectOrigin(connects,e)
-    case l if (checkLit(l)) => e
-    case _ => getConnectOrigin(connects,e.serialize)  
-  }
-
-  // takes in a list of connections in a given module and looks to find the origin of some node
-  // where origin is the source of a connect. note that if the source is a trivial primop that
-  // has yet to be optimized via constant propagation, the function will try to search backwards
-  // past the primop. this allows you to compare if two nodes have the same origin, for example. 
-  // backward searches until PrimOp, Lit or non-trivial Mux appears
-  // technically, you should keep searching through PrimOp, because a node + 0 is still itself, 
-  // a node shifted by 0 is still itself, etc. 
-  // TODO: handle validif???, more thorough
-  private def getConnectOrigin(connects: Map[String, Expression], e: Expression): Expression = e match { 
+  private def getOrigin(connects: Map[String, Expression], e: Expression): Expression = e match { 
     case Mux(cond, tv, fv, _) =>
-      val fvOrigin = getOrigin(connects,fv)
-      val tvOrigin = getOrigin(connects,tv)
-      val condOrigin = getOrigin(connects,cond)
+      val fvOrigin = getOrigin(connects, fv)
+      val tvOrigin = getOrigin(connects, tv)
+      val condOrigin = getOrigin(connects, cond)
       if (we(tvOrigin) == we(one) && we(fvOrigin) == we(zero)) condOrigin
       else if (we(condOrigin) == we(one)) tvOrigin
       else if (we(condOrigin) == we(zero)) fvOrigin
@@ -73,27 +62,25 @@ object AnalysisUtils {
       else e
     case DoPrim(PrimOps.Or, args, consts, tpe) if args.contains(one) => one
     case DoPrim(PrimOps.And, args, consts, tpe) if args.contains(zero) => zero
-    case DoPrim(PrimOps.Bits, args, consts, tpe) =>  
-      val msb = consts(0)
-      val lsb = consts(1) 
+    case DoPrim(PrimOps.Bits, args, Seq(msb, lsb), tpe) =>  
       val extractionWidth = (msb-lsb)+1
       val nodeWidth = bitWidth(args.head.tpe)
       // if you're extracting the full bitwidth, then keep searching for origin
-      if (nodeWidth == extractionWidth) getOrigin(connects,args.head)
+      if (nodeWidth == extractionWidth) getOrigin(connects, args.head)
       else e
-    case DoPrim(op, args, _, _) if (op == PrimOps.AsUInt || op == PrimOps.AsSInt || op == PrimOps.AsClock) =>
-      getOrigin(connects,args.head)
+    case DoPrim((PrimOps.AsUInt | PrimOps.AsSInt | PrimOps.AsClock), args, _, _) => 
+      getOrigin(connects, args.head)
     case _: WRef | _: SubField | _: SubIndex | _: SubAccess if connects contains e.serialize =>
-      getConnectOrigin(connects,e.serialize) 
+      getConnectOrigin(connects, e.serialize) 
     case _ => e
   }
 
-  def appendInfo[T <: Info](info: T, add: Map[String,Any]) = info match {
+  def appendInfo[T <: Info](info: T, add: Map[String, Any]) = info match {
     case i: AppendableInfo => i.append(add)
     case _ => AppendableInfo(fields = add + ("info" -> info))
   }
-  def appendInfo[T <: Info](info: T, add: (String,Any)): AppendableInfo = appendInfo(info,Map(add))
-  def getInfo[T <: Info](info: T, k: String) = info match{
+  def appendInfo[T <: Info](info: T, add: (String, Any)): AppendableInfo = appendInfo(info, Map(add))
+  def getInfo[T <: Info](info: T, k: String) = info match {
     case i: AppendableInfo => i.get(k)
     case _ => None
   }
@@ -102,17 +89,8 @@ object AnalysisUtils {
     case _ => false
   }
 
-  def eqMems(a: DefMemory, b: DefMemory) = {
-    a.info == b.info &&
-    a.dataType == b.dataType &&
-    a.depth == b.depth &&
-    a.writeLatency == b.writeLatency &&
-    a.readLatency == b.readLatency &&
-    a.readers == b.readers &&
-    a.writers == b.writers &&
-    a.readwriters == b.readwriters &&
-    a.readUnderWrite == b.readUnderWrite
-  }  
+  // memories equivalent as long as all fields (except name) are the same
+  def eqMems(a: DefMemory, b: DefMemory) = a == b.copy(name = a.name) 
 
 }
 
@@ -127,9 +105,9 @@ object AnnotateMemMacros extends Pass {
 
       // returns # of mask bits if used
       def getMaskBits(wen: String, wmask: String): Option[Int] = {
-        val wenOrigin = we(getConnectOrigin(connects,wen))
+        val wenOrigin = we(getConnectOrigin(connects, wen))
         val one1 = we(one)
-        val wmaskOrigin = connects.keys.toSeq.filter(_.startsWith(wmask)).map(x => we(getConnectOrigin(connects,x)))
+        val wmaskOrigin = connects.keys.toSeq.filter(_.startsWith(wmask)).map(x => we(getConnectOrigin(connects, x)))
         // all wmask bits are equal to wmode/wen or all wmask bits = 1(for redundancy checking)
         val redundantMask = wmaskOrigin.map( x => (x == wenOrigin) || (x == one1) ).foldLeft(true)(_ && _)
         if (redundantMask) None else Some(wmaskOrigin.length)
@@ -137,15 +115,15 @@ object AnnotateMemMacros extends Pass {
 
       def updateStmts(s: Statement): Statement = s match {
         // only annotate memories that are candidates for memory macro replacements
-        // i.e. rw, w + r (read,write 1 cycle delay)
+        // i.e. rw, w + r (read, write 1 cycle delay)
         case m: DefMemory if m.readLatency == 1 && m.writeLatency == 1 && 
             (m.writers.length + m.readwriters.length) == 1 && m.readers.length <= 1 =>
           val dataBits = bitWidth(m.dataType)
-          val rwMasks = m.readwriters map (w => getMaskBits(s"${m.name}.$w.wmode",s"${m.name}.$w.wmask"))
-          val wMasks = m.writers map (w => getMaskBits(s"${m.name}.$w.en",s"${m.name}.$w.mask"))
+          val rwMasks = m.readwriters map (w => getMaskBits(s"${m.name}.$w.wmode", s"${m.name}.$w.wmask"))
+          val wMasks = m.writers map (w => getMaskBits(s"${m.name}.$w.en", s"${m.name}.$w.mask"))
           val maskBits = (rwMasks ++ wMasks).head
           val memAnnotations = Map("useMacro" -> true)
-          val tempInfo = appendInfo(m.info,memAnnotations)
+          val tempInfo = appendInfo(m.info, memAnnotations)
           if (maskBits == None) m.copy(info = tempInfo)
           else m.copy(info = tempInfo.append("maskGran" -> dataBits/maskBits.get))       
         case b: Block => b map updateStmts

--- a/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
+++ b/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
@@ -12,7 +12,8 @@ object CustomYAMLProtocol extends DefaultYamlProtocol {
   implicit val dr = yamlFormat4(DimensionRules)
   implicit val md = yamlFormat2(MemDimension)
   implicit val sr = yamlFormat4(SRAMRules)
-  implicit val sc = yamlFormat11(SRAMCompiler)
+  implicit val wm = yamlFormat2(WMaskArg)
+  implicit val sc = yamlFormat10(SRAMCompiler)
 }
 
 case class DimensionRules(
@@ -37,15 +38,19 @@ case class MemDimension(
     if(rules == None) set != None else set == None, 
     "Should specify either rules or a list of valid options, but not both"
   )
-  def getValid = set.getOrElse(rules.get.getValid)
+  def getValid = set.getOrElse(rules.get.getValid).sorted
 }
 
 case class SRAMConfig(
-  ymux: String,
-  ybank: String,
-  width: String,
-  depth: String
+  ymux: String = "",
+  ybank: String = "",
+  width: Int,
+  depth: Int,
+  xsplit: Int = 1,
+  ysplit: Int = 1
 ){
+  // how many duplicate copies of this SRAM are needed
+  def num = xsplit * ysplit
   def serialize(pattern: String): String = {
     val fieldMap = getClass.getDeclaredFields.map{f => 
       f.setAccessible(true)
@@ -77,16 +82,19 @@ case class SRAMRules(
 ){
   def getValidWidths = width.getValid
   def getValidDepths = depth.getValid
-  def getValidConfig(m: DefMemory): Option[SRAMConfig] = {
-    val width = bitWidth(m.dataType)
-    val depth = m.depth
+  def getValidConfig(width: Int, depth: Int): Option[SRAMConfig] = {
     if (getValidWidths.contains(width) && getValidDepths.contains(depth)) 
-      Some(SRAMConfig(ymux = ymux._2, ybank = ybank._2, width = width.toString, depth = depth.toString))
+      Some(SRAMConfig(ymux = ymux._2, ybank = ybank._2, width = width, depth = depth))
     else
       None
   }
-
+  def getValidConfig(m: DefMemory): Option[SRAMConfig] = getValidConfig(bitWidth(m.dataType).intValue,m.depth) 
 } 
+
+case class WMaskArg(
+  t: String,
+  f: String
+)
 
 // vendor-specific compilers
 case class SRAMCompiler(
@@ -95,9 +103,7 @@ case class SRAMCompiler(
     // i.e. RF, SRAM, etc.
     memType: String,
     portType: String,
-    useWmask: Boolean,
-    // area of individual bitcells (um2) to determine periphery overhead
-    bitCellArea: Option[Double],
+    wMaskArg: Option[WMaskArg],
     // rules for valid SRAM flavors
     rules: Seq[SRAMRules],
     // path to executable 
@@ -111,90 +117,173 @@ case class SRAMCompiler(
 ){
   require(portType == "RW" || portType == "R,W", "Memory must be single port RW or dual port R,W")
   require(
-    (configFile != None && configPattern != None) || configFile == None, 
+    (configFile != None && configPattern != None && wMaskArg != None) || configFile == None, 
     "Config pattern must be provided with config file"
   ) 
   def ymuxVals = rules.map(_.ymux._1).sortWith(_ < _)
   def ybankVals = rules.map(_.ybank._1).sortWith(_ > _)
+  // TODO: verify this default ordering works out
   // optimize search for better FoM (area,power,clk); ymux has more effect
   def defaultSearchOrdering = for (x <- ymuxVals; y <- ybankVals) yield {
     rules.find(r => r.ymux._1 == x && r.ybank._1 == y).get
   }
 
-  private val configOutputBuffer = new java.io.CharArrayWriter
+  private val maskConfigOutputBuffer = new java.io.CharArrayWriter
+  private val noMaskConfigOutputBuffer = new java.io.CharArrayWriter
 
-  def append(m: DefMemory) : Option[SRAMConfig] = {
+  def append(m: DefMemory) : DefMemory = {
     val validCombos = ArrayBuffer[SRAMConfig]()
     defaultSearchOrdering foreach { r =>
       val config = r.getValidConfig(m)
       if (config != None) validCombos += config.get
     }
     // non empty if successfully found compiler option that supports depth/width
-    if (validCombos.nonEmpty){ 
-      if (configPattern != None) 
-        configOutputBuffer.append(validCombos.head.serialize(configPattern.get))
-      Some(validCombos.head)
+    // TODO: don't just take first option
+    val usedConfig = {
+      if (validCombos.nonEmpty) validCombos.head
+      else getBestAlternative(m)
     }
-    else None
+    if (configPattern != None) {
+      val newConfig = usedConfig.serialize(configPattern.get) + "\n"
+      val currentBuff = {
+        if (containsInfo(m.info,"maskGran")) maskConfigOutputBuffer 
+        else noMaskConfigOutputBuffer
+      }
+      if (!currentBuff.toString.contains(newConfig))
+        currentBuff.append(newConfig)
+    }
+    m.copy(info = appendInfo(m.info,"sramConfig" -> usedConfig))    
   }
 
-  // # of mems with given width, depth to make up the memory you want
-  private case class MemInfo(num: Int, width: Int, depth: Int)
-
+  // TODO: Should you really be splitting in 2 if, say, depth is 1 more than allowed? should be thresholded and
+  // handled w/ a separate set of registers ?
   // split memory until width, depth achievable via given memory compiler
-  private def getInRange(m: MemInfo): Seq[MemInfo] = {
+  private def getInRange(m: SRAMConfig): Seq[SRAMConfig] = {
     val validXRange = ArrayBuffer[SRAMRules]()
     val validYRange = ArrayBuffer[SRAMRules]()
     defaultSearchOrdering foreach { r => 
-      if (m.width < r.getValidWidths.max) validXRange += r
-      if (m.depth < r.getValidDepths.max) validYRange += r
+      if (m.width <= r.getValidWidths.max) validXRange += r
+      if (m.depth <= r.getValidDepths.max) validYRange += r
     }
+
     if (validXRange.isEmpty && validYRange.isEmpty)
-      getInRange(MemInfo(4*m.num,m.width/2,m.depth/2))
+      getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = 2*m.ysplit, width = m.width/2,depth = m.depth/2))
     else if (validXRange.isEmpty && validYRange.nonEmpty)
-      getInRange(MemInfo(2*m.num,m.width/2,m.depth)) 
+      getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = m.ysplit, width = m.width/2,depth = m.depth)) 
     else if (validXRange.nonEmpty && validYRange.isEmpty)
-      getInRange(MemInfo(2*m.num,m.width,m.depth/2)) 
-    else if (validXRange.union(validYRange).nonEmpty)
+      getInRange(SRAMConfig(xsplit = m.xsplit, ysplit = 2*m.ysplit, width = m.width,depth = m.depth/2)) 
+    else if (validXRange.intersect(validYRange).nonEmpty)
       Seq(m)
     else 
-      getInRange(MemInfo(2*m.num,m.width,m.depth/2)) ++ getInRange(MemInfo(2*m.num,m.width/2,m.depth))    
+      getInRange(SRAMConfig(xsplit = m.xsplit, ysplit = 2*m.ysplit, width = m.width,depth = m.depth/2)) ++ 
+        getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = m.ysplit, width = m.width/2,depth = m.depth))    
+  }
+
+  private def getBestAlternative(m: DefMemory): SRAMConfig = {
+    val validConfigs = getInRange(SRAMConfig(width = bitWidth(m.dataType).intValue, depth = m.depth))
+    val minNum = validConfigs.map(x => x.num).min
+    val validMinConfigs = validConfigs.filter(_.num == minNum)
+    val validMinConfigsSquareness = validMinConfigs.map(x => math.abs(x.width.toDouble/x.depth - 1) -> x).toMap
+    val squarestAspectRatio = validMinConfigsSquareness.map(x => x._1).min
+    val validConfig = validMinConfigsSquareness(squarestAspectRatio)
+    val validRules = ArrayBuffer[SRAMRules]()
+    defaultSearchOrdering foreach { r =>
+      if (validConfig.width <= r.getValidWidths.max && validConfig.depth <= r.getValidDepths.max) validRules += r
+    }
+    // TODO: don't just take first option
+    val bestRule = validRules.head
+    val memWidth = bestRule.getValidWidths.find(validConfig.width <= _).get
+    val memDepth = bestRule.getValidDepths.find(validConfig.depth <= _).get
+    bestRule.getValidConfig(width = memWidth, depth = memDepth).get.copy(xsplit = validConfig.xsplit, ysplit = validConfig.ysplit)
+  }
+
+  def serialize() = {
+    // TODO
   }
 
 }  
 
+// TODO: assumption that you would stick to just SRAMs or just RFs in a design -- is that true?
+// Or is this where module-level transforms (rather than circuit-level) make sense?
 class YamlFileReader(file: String){
   import CustomYAMLProtocol._
-  def parse: Seq[YamlValue] = {
-    val yamlString = scala.io.Source.fromFile(file).getLines.mkString("\n")
-    yamlString.parseYamls
+  def parse[A](implicit reader: YamlReader[A]) : Seq[A] = {
+    if (new java.io.File(file).exists) {
+      val yamlString = scala.io.Source.fromFile(file).getLines.mkString("\n")
+      val optionOut = yamlString.parseYamls.map(x => 
+        try Some(reader.read(x))
+        catch {case e: Exception => None} 
+      )
+      optionOut.filter(_ != None).map(_.get)
+    }
+    else Error("Yaml file doesn't exist!")
+  }
+}
+
+class YamlFileWriter(file: String) {
+  import CustomYAMLProtocol._
+  val outputBuffer = new java.io.CharArrayWriter
+  val separator = "--- \n"
+  def append(in: YamlValue) = {
+    outputBuffer.append(separator + in.prettyPrint)
+  }
+  def serialize = {
+    val outputFile = new java.io.PrintWriter(file)
+    outputFile.write(outputBuffer.toString)
+    outputFile.close()
   }
 }
 
 class AnnotateValidMemConfigs(reader: Option[YamlFileReader]) extends Pass {
 
+  import CustomYAMLProtocol._
+
   def name = "Annotate memories with valid split depths, widths, #\'s"
 
-  def run(c: Circuit) = {
+  // TODO: Consider splitting InferRW to analysis + actual optimization pass, in case sp doesn't exist
+  // TODO: Don't get first available? 
+  case class SRAMCompilerSet(
+    sp: Option[SRAMCompiler] = None, 
+    dp: Option[SRAMCompiler] = None 
+  ){
+    def serialize() = {
+      if (sp != None) sp.get.serialize()
+      if (dp != None) dp.get.serialize()
+    }
+  }
+  val sramCompilers = {
+    if (reader == None) None
+    else {
+      val compilers = reader.get.parse[SRAMCompiler] 
+      val sp = compilers.find(_.portType == "RW")
+      val dp = compilers.find(_.portType == "R,W")
+      Some(SRAMCompilerSet(sp = sp, dp = dp))
+    }
+  }
 
+  def run(c: Circuit) = {
     def annotateModMems(m: Module) = {
-      
       def updateStmts(s: Statement): Statement = s match {
-        
-        case m: DefMemory if containsInfo(m.info,"useMacro") => m   
+        case m: DefMemory if containsInfo(m.info,"useMacro") => {
+          if (sramCompilers == None) m 
+          else {
+            if (m.readwriters.length == 1)
+              if (sramCompilers.get.sp == None) Error("Design needs RW port memory compiler!")
+              else sramCompilers.get.sp.get.append(m)
+            else
+              if (sramCompilers.get.dp == None) Error("Design needs R,W port memory compiler!")
+              else sramCompilers.get.dp.get.append(m)
+          }
+        }  
         case b: Block => Block(b.stmts map updateStmts)
         case s => s
-
       }
       m.copy(body=updateStmts(m.body))
     } 
-
     val updatedMods = c.modules map {
       case m: Module => annotateModMems(m)
       case m: ExtModule => m
     }
     c.copy(modules = updatedMods)
-
   }  
-
 }

--- a/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
+++ b/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
@@ -1,0 +1,200 @@
+package firrtl.passes
+
+import firrtl.ir._
+import firrtl._
+import net.jcazevedo.moultingyaml._
+import net.jcazevedo.moultingyaml.DefaultYamlProtocol._
+import AnalysisUtils._
+import scala.collection.mutable.ArrayBuffer
+
+object CustomYAMLProtocol extends DefaultYamlProtocol {
+  // bottom depends on top
+  implicit val dr = yamlFormat4(DimensionRules)
+  implicit val md = yamlFormat2(MemDimension)
+  implicit val sr = yamlFormat4(SRAMRules)
+  implicit val sc = yamlFormat11(SRAMCompiler)
+}
+
+case class DimensionRules(
+  min: Int,
+  // step size
+  inc: Int,
+  max: Int,
+  // these values should not be used, regardless of min,inc,max
+  illegal: Option[List[Int]]
+){
+  def getValid = {
+    val range = (min to max by inc).toList
+    range.filterNot(illegal.getOrElse(List[Int]()).toSet)
+  }
+}
+
+case class MemDimension(
+  rules: Option[DimensionRules],
+  set: Option[List[Int]]
+){
+  require (
+    if(rules == None) set != None else set == None, 
+    "Should specify either rules or a list of valid options, but not both"
+  )
+  def getValid = set.getOrElse(rules.get.getValid)
+}
+
+case class SRAMConfig(
+  ymux: String,
+  ybank: String,
+  width: String,
+  depth: String
+){
+  def serialize(pattern: String): String = {
+    val fieldMap = getClass.getDeclaredFields.map{f => 
+      f.setAccessible(true)
+      f.getName -> f.get(this)
+    }.toMap
+
+    val fieldDelimiter = """\[.*?\]""".r
+    val configOptions = fieldDelimiter.findAllIn(pattern).toList
+
+    configOptions.foldLeft(pattern)((b,a) => {
+      // Expects the contents of [] are valid configuration fields (otherwise key match error)
+      val fieldVal = {
+        try fieldMap(a.substring(1,a.length-1)) 
+        catch { case e: Exception => Error("**SRAM config field incorrect**") }
+      }
+      b.replace(a,fieldVal.toString)
+    })
+  }
+}
+
+// Ex: https://www.ece.cmu.edu/~ece548/hw/hw5/meml80.pdf
+case class SRAMRules(
+  // column mux parameter (for adjusting aspect ratio)
+  ymux: (Int,String),
+  // vertical segmentation (banking -- tradeoff performance / area)
+  ybank: (Int,String),
+  width: MemDimension,
+  depth: MemDimension
+){
+  def getValidWidths = width.getValid
+  def getValidDepths = depth.getValid
+  def getValidConfig(m: DefMemory): Option[SRAMConfig] = {
+    val width = bitWidth(m.dataType)
+    val depth = m.depth
+    if (getValidWidths.contains(width) && getValidDepths.contains(depth)) 
+      Some(SRAMConfig(ymux = ymux._2, ybank = ybank._2, width = width.toString, depth = depth.toString))
+    else
+      None
+  }
+
+} 
+
+// vendor-specific compilers
+case class SRAMCompiler(
+    vendor: String,
+    node: String,
+    // i.e. RF, SRAM, etc.
+    memType: String,
+    portType: String,
+    useWmask: Boolean,
+    // area of individual bitcells (um2) to determine periphery overhead
+    bitCellArea: Option[Double],
+    // rules for valid SRAM flavors
+    rules: Seq[SRAMRules],
+    // path to executable 
+    path: Option[String],
+    // (output) config file path
+    configFile: Option[String],
+    // config pattern
+    configPattern: Option[String],
+    // read documentation for details 
+    defaultArgs: Option[String]
+){
+  require(portType == "RW" || portType == "R,W", "Memory must be single port RW or dual port R,W")
+  require(
+    (configFile != None && configPattern != None) || configFile == None, 
+    "Config pattern must be provided with config file"
+  ) 
+  def ymuxVals = rules.map(_.ymux._1).sortWith(_ < _)
+  def ybankVals = rules.map(_.ybank._1).sortWith(_ > _)
+  // optimize search for better FoM (area,power,clk); ymux has more effect
+  def defaultSearchOrdering = for (x <- ymuxVals; y <- ybankVals) yield {
+    rules.find(r => r.ymux._1 == x && r.ybank._1 == y).get
+  }
+
+  private val configOutputBuffer = new java.io.CharArrayWriter
+
+  def append(m: DefMemory) : Option[SRAMConfig] = {
+    val validCombos = ArrayBuffer[SRAMConfig]()
+    defaultSearchOrdering foreach { r =>
+      val config = r.getValidConfig(m)
+      if (config != None) validCombos += config.get
+    }
+    // non empty if successfully found compiler option that supports depth/width
+    if (validCombos.nonEmpty){ 
+      if (configPattern != None) 
+        configOutputBuffer.append(validCombos.head.serialize(configPattern.get))
+      Some(validCombos.head)
+    }
+    else None
+  }
+
+  // # of mems with given width, depth to make up the memory you want
+  private case class MemInfo(num: Int, width: Int, depth: Int)
+
+  // split memory until width, depth achievable via given memory compiler
+  private def getInRange(m: MemInfo): Seq[MemInfo] = {
+    val validXRange = ArrayBuffer[SRAMRules]()
+    val validYRange = ArrayBuffer[SRAMRules]()
+    defaultSearchOrdering foreach { r => 
+      if (m.width < r.getValidWidths.max) validXRange += r
+      if (m.depth < r.getValidDepths.max) validYRange += r
+    }
+    if (validXRange.isEmpty && validYRange.isEmpty)
+      getInRange(MemInfo(4*m.num,m.width/2,m.depth/2))
+    else if (validXRange.isEmpty && validYRange.nonEmpty)
+      getInRange(MemInfo(2*m.num,m.width/2,m.depth)) 
+    else if (validXRange.nonEmpty && validYRange.isEmpty)
+      getInRange(MemInfo(2*m.num,m.width,m.depth/2)) 
+    else if (validXRange.union(validYRange).nonEmpty)
+      Seq(m)
+    else 
+      getInRange(MemInfo(2*m.num,m.width,m.depth/2)) ++ getInRange(MemInfo(2*m.num,m.width/2,m.depth))    
+  }
+
+}  
+
+class YamlFileReader(file: String){
+  import CustomYAMLProtocol._
+  def parse: Seq[YamlValue] = {
+    val yamlString = scala.io.Source.fromFile(file).getLines.mkString("\n")
+    yamlString.parseYamls
+  }
+}
+
+class AnnotateValidMemConfigs(reader: Option[YamlFileReader]) extends Pass {
+
+  def name = "Annotate memories with valid split depths, widths, #\'s"
+
+  def run(c: Circuit) = {
+
+    def annotateModMems(m: Module) = {
+      
+      def updateStmts(s: Statement): Statement = s match {
+        
+        case m: DefMemory if containsInfo(m.info,"useMacro") => m   
+        case b: Block => Block(b.stmts map updateStmts)
+        case s => s
+
+      }
+      m.copy(body=updateStmts(m.body))
+    } 
+
+    val updatedMods = c.modules map {
+      case m: Module => annotateModMems(m)
+      case m: ExtModule => m
+    }
+    c.copy(modules = updatedMods)
+
+  }  
+
+}

--- a/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
+++ b/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package firrtl.passes
 
 import firrtl.ir._
@@ -5,7 +7,7 @@ import firrtl._
 import net.jcazevedo.moultingyaml._
 import net.jcazevedo.moultingyaml.DefaultYamlProtocol._
 import AnalysisUtils._
-import scala.collection.mutable.ArrayBuffer
+import scala.collection._
 import firrtl.Mappers._
 
 object CustomYAMLProtocol extends DefaultYamlProtocol {
@@ -18,13 +20,12 @@ object CustomYAMLProtocol extends DefaultYamlProtocol {
 }
 
 case class DimensionRules(
-  min: Int,
-  // step size
-  inc: Int,
-  max: Int,
-  // these values should not be used, regardless of min,inc,max
-  illegal: Option[List[Int]]
-){
+    min: Int,
+    // step size
+    inc: Int,
+    max: Int,
+    // these values should not be used, regardless of min,inc,max
+    illegal: Option[List[Int]]) {
   def getValid = {
     val range = (min to max by inc).toList
     range.filterNot(illegal.getOrElse(List[Int]()).toSet)
@@ -32,9 +33,8 @@ case class DimensionRules(
 }
 
 case class MemDimension(
-  rules: Option[DimensionRules],
-  set: Option[List[Int]]
-){
+    rules: Option[DimensionRules],
+    set: Option[List[Int]]) {
   require (
     if(rules == None) set != None else set == None, 
     "Should specify either rules or a list of valid options, but not both"
@@ -43,44 +43,42 @@ case class MemDimension(
 }
 
 case class SRAMConfig(
-  ymux: String = "",
-  ybank: String = "",
-  width: Int,
-  depth: Int,
-  xsplit: Int = 1,
-  ysplit: Int = 1
-){
+    ymux: String = "",
+    ybank: String = "",
+    width: Int,
+    depth: Int,
+    xsplit: Int = 1,
+    ysplit: Int = 1) {
   // how many duplicate copies of this SRAM are needed
   def num = xsplit * ysplit
   def serialize(pattern: String): String = {
-    val fieldMap = getClass.getDeclaredFields.map{f => 
+    val fieldMap = getClass.getDeclaredFields.map { f => 
       f.setAccessible(true)
       f.getName -> f.get(this)
-    }.toMap
+    } toMap
 
     val fieldDelimiter = """\[.*?\]""".r
     val configOptions = fieldDelimiter.findAllIn(pattern).toList
 
-    configOptions.foldLeft(pattern)((b,a) => {
+    configOptions.foldLeft(pattern)((b, a) => {
       // Expects the contents of [] are valid configuration fields (otherwise key match error)
       val fieldVal = {
-        try fieldMap(a.substring(1,a.length-1)) 
+        try fieldMap(a.substring(1, a.length-1)) 
         catch { case e: Exception => error("**SRAM config field incorrect**") }
       }
-      b.replace(a,fieldVal.toString)
-    })
+      b.replace(a, fieldVal.toString)
+    } )
   }
 }
 
 // Ex: https://www.ece.cmu.edu/~ece548/hw/hw5/meml80.pdf
 case class SRAMRules(
-  // column mux parameter (for adjusting aspect ratio)
-  ymux: (Int,String),
-  // vertical segmentation (banking -- tradeoff performance / area)
-  ybank: (Int,String),
-  width: MemDimension,
-  depth: MemDimension
-){
+    // column mux parameter (for adjusting aspect ratio)
+    ymux: (Int, String),
+    // vertical segmentation (banking -- tradeoff performance / area)
+    ybank: (Int, String),
+    width: MemDimension,
+    depth: MemDimension) {
   def getValidWidths = width.getValid
   def getValidDepths = depth.getValid
   def getValidConfig(width: Int, depth: Int): Option[SRAMConfig] = {
@@ -89,13 +87,12 @@ case class SRAMRules(
     else
       None
   }
-  def getValidConfig(m: DefMemory): Option[SRAMConfig] = getValidConfig(bitWidth(m.dataType).intValue,m.depth) 
+  def getValidConfig(m: DefMemory): Option[SRAMConfig] = getValidConfig(bitWidth(m.dataType).intValue, m.depth) 
 } 
 
 case class WMaskArg(
-  t: String,
-  f: String
-)
+    t: String,
+    f: String)
 
 // vendor-specific compilers
 case class SRAMCompiler(
@@ -117,8 +114,7 @@ case class SRAMCompiler(
     defaultArgs: Option[String],
     // default behavior (if not used) is to have wmask port width = datawidth/maskgran
     // if true: wmask port width pre-filled to datawidth
-    fillWMask: Boolean
-){
+    fillWMask: Boolean) {
   require(portType == "RW" || portType == "R,W", "Memory must be single port RW or dual port R,W")
   require(
     (configFile != None && configPattern != None && wMaskArg != None) || configFile == None, 
@@ -136,7 +132,7 @@ case class SRAMCompiler(
   private val noMaskConfigOutputBuffer = new java.io.CharArrayWriter
 
   def append(m: DefMemory) : DefMemory = {
-    val validCombos = ArrayBuffer[SRAMConfig]()
+    val validCombos = mutable.ArrayBuffer[SRAMConfig]()
     defaultSearchOrdering foreach { r =>
       val config = r.getValidConfig(m)
       if (config != None) validCombos += config.get
@@ -147,7 +143,7 @@ case class SRAMCompiler(
       if (validCombos.nonEmpty) validCombos.head
       else getBestAlternative(m)
     }
-    val usesMaskGran = containsInfo(m.info,"maskGran")
+    val usesMaskGran = containsInfo(m.info, "maskGran")
     if (configPattern != None) {
       val newConfig = usedConfig.serialize(configPattern.get) + "\n"
       val currentBuff = {
@@ -157,8 +153,8 @@ case class SRAMCompiler(
       if (!currentBuff.toString.contains(newConfig))
         currentBuff.append(newConfig)
     }
-    val temp = appendInfo(m.info,"sramConfig" -> usedConfig)
-    val newInfo = if(usesMaskGran && fillWMask) appendInfo(temp,"maskGran" -> 1) else temp
+    val temp = appendInfo(m.info, "sramConfig" -> usedConfig)
+    val newInfo = if(usesMaskGran && fillWMask) appendInfo(temp, "maskGran" -> 1) else temp
     m.copy(info = newInfo)    
   }
 
@@ -166,24 +162,24 @@ case class SRAMCompiler(
   // handled w/ a separate set of registers ?
   // split memory until width, depth achievable via given memory compiler
   private def getInRange(m: SRAMConfig): Seq[SRAMConfig] = {
-    val validXRange = ArrayBuffer[SRAMRules]()
-    val validYRange = ArrayBuffer[SRAMRules]()
+    val validXRange = mutable.ArrayBuffer[SRAMRules]()
+    val validYRange = mutable.ArrayBuffer[SRAMRules]()
     defaultSearchOrdering foreach { r => 
       if (m.width <= r.getValidWidths.max) validXRange += r
       if (m.depth <= r.getValidDepths.max) validYRange += r
     }
 
     if (validXRange.isEmpty && validYRange.isEmpty)
-      getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = 2*m.ysplit, width = m.width/2,depth = m.depth/2))
+      getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = 2*m.ysplit, width = m.width/2, depth = m.depth/2))
     else if (validXRange.isEmpty && validYRange.nonEmpty)
-      getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = m.ysplit, width = m.width/2,depth = m.depth)) 
+      getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = m.ysplit, width = m.width/2, depth = m.depth)) 
     else if (validXRange.nonEmpty && validYRange.isEmpty)
-      getInRange(SRAMConfig(xsplit = m.xsplit, ysplit = 2*m.ysplit, width = m.width,depth = m.depth/2)) 
+      getInRange(SRAMConfig(xsplit = m.xsplit, ysplit = 2*m.ysplit, width = m.width, depth = m.depth/2)) 
     else if (validXRange.intersect(validYRange).nonEmpty)
       Seq(m)
     else 
-      getInRange(SRAMConfig(xsplit = m.xsplit, ysplit = 2*m.ysplit, width = m.width,depth = m.depth/2)) ++ 
-        getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = m.ysplit, width = m.width/2,depth = m.depth))    
+      getInRange(SRAMConfig(xsplit = m.xsplit, ysplit = 2*m.ysplit, width = m.width, depth = m.depth/2)) ++ 
+        getInRange(SRAMConfig(xsplit = 2*m.xsplit, ysplit = m.ysplit, width = m.width/2, depth = m.depth))    
   }
 
   private def getBestAlternative(m: DefMemory): SRAMConfig = {
@@ -191,9 +187,9 @@ case class SRAMCompiler(
     val minNum = validConfigs.map(x => x.num).min
     val validMinConfigs = validConfigs.filter(_.num == minNum)
     val validMinConfigsSquareness = validMinConfigs.map(x => math.abs(x.width.toDouble/x.depth - 1) -> x).toMap
-    val squarestAspectRatio = validMinConfigsSquareness.map(x => x._1).min
+    val squarestAspectRatio = validMinConfigsSquareness.map { case (aspectRatioDiff, _) => aspectRatioDiff } min
     val validConfig = validMinConfigsSquareness(squarestAspectRatio)
-    val validRules = ArrayBuffer[SRAMRules]()
+    val validRules = mutable.ArrayBuffer[SRAMRules]()
     defaultSearchOrdering foreach { r =>
       if (validConfig.width <= r.getValidWidths.max && validConfig.depth <= r.getValidDepths.max) validRules += r
     }
@@ -206,7 +202,7 @@ case class SRAMCompiler(
     bestRule.getValidConfig(width = memWidth, depth = memDepth).get.copy(xsplit = validConfig.xsplit, ysplit = validConfig.ysplit)
   }
 
-  def serialize() = {
+  def serialize = {
     // TODO
   }
 
@@ -214,16 +210,15 @@ case class SRAMCompiler(
 
 // TODO: assumption that you would stick to just SRAMs or just RFs in a design -- is that true?
 // Or is this where module-level transforms (rather than circuit-level) make sense?
-class YamlFileReader(file: String){
+class YamlFileReader(file: String) {
   import CustomYAMLProtocol._
   def parse[A](implicit reader: YamlReader[A]) : Seq[A] = {
     if (new java.io.File(file).exists) {
       val yamlString = scala.io.Source.fromFile(file).getLines.mkString("\n")
-      val optionOut = yamlString.parseYamls.map(x => 
+      yamlString.parseYamls.flatMap(x => 
         try Some(reader.read(x))
-        catch {case e: Exception => None} 
+        catch { case e: Exception => None } 
       )
-      optionOut.filter(_ != None).map(_.get)
     }
     else error("Yaml file doesn't exist!")
   }
@@ -236,7 +231,7 @@ class YamlFileWriter(file: String) {
   def append(in: YamlValue) = {
     outputBuffer.append(separator + in.prettyPrint)
   }
-  def serialize = {
+  def dump = {
     val outputFile = new java.io.PrintWriter(file)
     outputFile.write(outputBuffer.toString)
     outputFile.close()
@@ -252,12 +247,11 @@ class AnnotateValidMemConfigs(reader: Option[YamlFileReader]) extends Pass {
   // TODO: Consider splitting InferRW to analysis + actual optimization pass, in case sp doesn't exist
   // TODO: Don't get first available? 
   case class SRAMCompilerSet(
-    sp: Option[SRAMCompiler] = None, 
-    dp: Option[SRAMCompiler] = None 
-  ){
-    def serialize() = {
-      if (sp != None) sp.get.serialize()
-      if (dp != None) dp.get.serialize()
+      sp: Option[SRAMCompiler] = None, 
+      dp: Option[SRAMCompiler] = None) {
+    def serialize = {
+      if (sp != None) sp.get.serialize
+      if (dp != None) dp.get.serialize
     }
   }
   val sramCompilers = {
@@ -273,7 +267,7 @@ class AnnotateValidMemConfigs(reader: Option[YamlFileReader]) extends Pass {
   def run(c: Circuit) = {
     def annotateModMems(m: Module) = {
       def updateStmts(s: Statement): Statement = s match {
-        case m: DefMemory if containsInfo(m.info,"useMacro") => {
+        case m: DefMemory if containsInfo(m.info, "useMacro") => {
           if (sramCompilers == None) m 
           else {
             if (m.readwriters.length == 1)

--- a/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
+++ b/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
@@ -202,9 +202,8 @@ case class SRAMCompiler(
     bestRule.getValidConfig(width = memWidth, depth = memDepth).get.copy(xsplit = validConfig.xsplit, ysplit = validConfig.ysplit)
   }
 
-  def serialize = {
-    // TODO
-  }
+  // TODO
+  def serialize = ???
 
 }  
 

--- a/src/main/scala/firrtl/passes/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/MemUtils.scala
@@ -41,22 +41,22 @@ object seqCat {
     case 2 => DoPrim(PrimOps.Cat, args, Seq.empty[BigInt], UIntType(UnknownWidth))
     case _ => {
       val seqs = args.splitAt(args.length/2)
-      DoPrim(PrimOps.Cat, Seq(seqCat(seqs._1),seqCat(seqs._2)), Seq.empty[BigInt], UIntType(UnknownWidth))
+      DoPrim(PrimOps.Cat, Seq(seqCat(seqs._1), seqCat(seqs._2)), Seq.empty[BigInt], UIntType(UnknownWidth))
     }
   }
 }
 
 object toBits {
   def apply(e: Expression): Expression = e match {
-    case ex: WRef => hiercat(ex,ex.tpe)
-    case ex: WSubField => hiercat(ex,ex.tpe)
-    case ex: WSubIndex => hiercat(ex,ex.tpe)
+    case ex: WRef => hiercat(ex, ex.tpe)
+    case ex: WSubField => hiercat(ex, ex.tpe)
+    case ex: WSubIndex => hiercat(ex, ex.tpe)
     case t => error("Invalid operand expression for toBits!")
   }
   def hiercat(e: Expression, dt: Type): Expression = dt match {
-    case t:VectorType => seqCat((0 until t.size).reverse.map(i => hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER),t.tpe)))
-    case t:BundleType => seqCat(t.fields.map(f => hiercat(WSubField(e, f.name, f.tpe, UNKNOWNGENDER), f.tpe)))
-    case t:GroundType => e
+    case t: VectorType => seqCat((0 until t.size).reverse.map(i => hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER), t.tpe)))
+    case t: BundleType => seqCat(t.fields.map(f => hiercat(WSubField(e, f.name, f.tpe, UNKNOWNGENDER), f.tpe)))
+    case t: GroundType => e
     case t => error("Unknown type encountered in toBits!")
   }
 }
@@ -64,16 +64,16 @@ object toBits {
 // TODO: make easier to understand
 object toBitMask {
   def apply(e: Expression, dataType: Type): Expression = e match {
-    case ex: WRef => hiermask(ex,ex.tpe,dataType)
-    case ex: WSubField => hiermask(ex,ex.tpe,dataType)
-    case ex: WSubIndex => hiermask(ex,ex.tpe,dataType)
+    case ex: WRef => hiermask(ex, ex.tpe, dataType)
+    case ex: WSubField => hiermask(ex, ex.tpe, dataType)
+    case ex: WSubIndex => hiermask(ex, ex.tpe, dataType)
     case t => error("Invalid operand expression for toBits!")
   }
   def hiermask(e: Expression, maskType: Type, dataType: Type): Expression = (maskType, dataType) match {
-    case (mt:VectorType, dt:VectorType) => seqCat((0 until mt.size).reverse.map(i => hiermask(WSubIndex(e, i, mt.tpe, UNKNOWNGENDER), mt.tpe, dt.tpe)))
-    case (mt:BundleType, dt:BundleType) => seqCat((mt.fields zip dt.fields).map{ case (mf,df) =>
-      hiermask(WSubField(e, mf.name, mf.tpe, UNKNOWNGENDER), mf.tpe, df.tpe) })
-    case (mt:UIntType, dt:GroundType) => seqCat(List.fill(bitWidth(dt).intValue)(e))
+    case (mt: VectorType, dt: VectorType) => seqCat((0 until mt.size).reverse.map(i => hiermask(WSubIndex(e, i, mt.tpe, UNKNOWNGENDER), mt.tpe, dt.tpe)))
+    case (mt: BundleType, dt: BundleType) => seqCat((mt.fields zip dt.fields).map { case (mf, df) =>
+      hiermask(WSubField(e, mf.name, mf.tpe, UNKNOWNGENDER), mf.tpe, df.tpe) } )
+    case (mt: UIntType, dt: GroundType) => seqCat(List.fill(bitWidth(dt).intValue)(e))
     case (mt, dt) => error("Invalid type for mask component!")
   }
 }
@@ -81,8 +81,8 @@ object toBitMask {
 object bitWidth {
   def apply(dt: Type): BigInt = widthOf(dt)
   def widthOf(dt: Type): BigInt = dt match {
-    case t:VectorType => t.size * bitWidth(t.tpe)
-    case t:BundleType => t.fields.map(f => bitWidth(f.tpe)).foldLeft(BigInt(0))(_+_)
+    case t: VectorType => t.size * bitWidth(t.tpe)
+    case t: BundleType => t.fields.map(f => bitWidth(f.tpe)).foldLeft(BigInt(0))(_+_)
     case UIntType(IntWidth(width)) => width
     case SIntType(IntWidth(width)) => width
     case t => error("Unknown type encountered in bitWidth!")
@@ -101,12 +101,12 @@ object fromBits {
   }
   def getPartGround(lhs: Expression, lhst: Type, rhs: Expression, offset: BigInt): (BigInt, Seq[Statement]) = {
     val intWidth = bitWidth(lhst)
-    val sel = DoPrim(PrimOps.Bits, Seq(rhs), Seq(offset+intWidth-1,offset), UnknownType)
-    (offset + intWidth, Seq(Connect(NoInfo,lhs,sel)))
+    val sel = DoPrim(PrimOps.Bits, Seq(rhs), Seq(offset+intWidth-1, offset), UnknownType)
+    (offset + intWidth, Seq(Connect(NoInfo, lhs, sel)))
   }
   def getPart(lhs: Expression, lhst: Type, rhs: Expression, offset: BigInt): (BigInt, Seq[Statement]) = {
     lhst match {
-      case t:VectorType => {
+      case t: VectorType => {
         var currentOffset = offset
         var stmts = Seq.empty[Statement]
         for (i <- (0 until t.size)) {
@@ -116,7 +116,7 @@ object fromBits {
         }
         (currentOffset, stmts)
       }
-      case t:BundleType => {
+      case t: BundleType => {
         var currentOffset = offset
         var stmts = Seq.empty[Statement]
         for (f <- t.fields.reverse) {
@@ -126,7 +126,7 @@ object fromBits {
         }
         (currentOffset, stmts)
       }
-      case t:GroundType => getPartGround(lhs, t, rhs, offset)
+      case t: GroundType => getPartGround(lhs, t, rhs, offset)
       case t => error("Unknown type encountered in fromBits!")
     }
   }
@@ -145,7 +145,7 @@ object MemPortUtils {
   )
 
   def getFillWMask(mem: DefMemory) = {
-    val maskGran = getInfo(mem.info,"maskGran")
+    val maskGran = getInfo(mem.info, "maskGran")
     if (maskGran == None) false
     else maskGran.get == 1
   }
@@ -156,7 +156,7 @@ object MemPortUtils {
   def wPortToBundle(mem: DefMemory) = {
     val defaultSeq = defaultPortSeq(mem) :+ Field("data", Default, mem.dataType)
     BundleType(
-      if (containsInfo(mem.info,"maskGran")) defaultSeq :+ Field("mask", Default, create_mask(mem.dataType))
+      if (containsInfo(mem.info, "maskGran")) defaultSeq :+ Field("mask", Default, create_mask(mem.dataType))
       else defaultSeq
     )
   }
@@ -164,7 +164,7 @@ object MemPortUtils {
   def wPortToFlattenBundle(mem: DefMemory) = {
     val defaultSeq = defaultPortSeq(mem) :+ Field("data", Default, flattenType(mem.dataType))
     BundleType(
-      if (containsInfo(mem.info,"maskGran")) {
+      if (containsInfo(mem.info, "maskGran")) {
         defaultSeq :+ {
           if (getFillWMask(mem)) Field("mask", Default, flattenType(mem.dataType))
           else Field("mask", Default, flattenType(create_mask(mem.dataType)))
@@ -175,26 +175,26 @@ object MemPortUtils {
   }
   // TODO: Don't use create_mask???
 
-  def rwPortToBundle(mem: DefMemory) ={
+  def rwPortToBundle(mem: DefMemory) = {
     val defaultSeq = defaultPortSeq(mem) ++ Seq(
       Field("wmode", Default, UIntType(IntWidth(1))),
       Field("wdata", Default, mem.dataType),
       Field("rdata", Flip, mem.dataType)
     )
     BundleType(
-      if (containsInfo(mem.info,"maskGran")) defaultSeq :+ Field("wmask", Default, create_mask(mem.dataType))
+      if (containsInfo(mem.info, "maskGran")) defaultSeq :+ Field("wmask", Default, create_mask(mem.dataType))
       else defaultSeq
     )
   }
 
-  def rwPortToFlattenBundle(mem: DefMemory) ={
+  def rwPortToFlattenBundle(mem: DefMemory) = {
     val defaultSeq = defaultPortSeq(mem) ++ Seq(
       Field("wmode", Default, UIntType(IntWidth(1))),
       Field("wdata", Default, flattenType(mem.dataType)),
       Field("rdata", Flip, flattenType(mem.dataType))
     )
     BundleType(
-      if (containsInfo(mem.info,"maskGran")) {
+      if (containsInfo(mem.info, "maskGran")) {
         defaultSeq :+ {
           if (getFillWMask(mem)) Field("wmask", Default, flattenType(mem.dataType))
           else Field("wmask", Default, flattenType(create_mask(mem.dataType)))

--- a/src/main/scala/firrtl/passes/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/MemUtils.scala
@@ -148,9 +148,9 @@ object MemPortUtils {
   def rwPortToBundle(mem: DefMemory) =
     BundleType(Seq(
       Field("wmode", Default, UIntType(IntWidth(1))),
-      Field("data", Default, mem.dataType),
+      Field("wdata", Default, mem.dataType),
       Field("rdata", Flip, mem.dataType),
-      Field("mask", Default, create_mask(mem.dataType)),
+      Field("wmask", Default, create_mask(mem.dataType)),
       Field("addr", Default, UIntType(IntWidth(ceil_log2(mem.depth)))),
       Field("en", Default, UIntType(IntWidth(1))),
       Field("clk", Default, ClockType)))

--- a/src/main/scala/firrtl/passes/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/MemUtils.scala
@@ -54,7 +54,7 @@ object toBits {
     case t => error("Invalid operand expression for toBits!")
   }
   def hiercat(e: Expression, dt: Type): Expression = dt match {
-    case t:VectorType => seqCat((0 until t.size).map(i => hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER),t.tpe)))
+    case t:VectorType => seqCat((0 until t.size).reverse.map(i => hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER),t.tpe)))
     case t:BundleType => seqCat(t.fields.map(f => hiercat(WSubField(e, f.name, f.tpe, UNKNOWNGENDER), f.tpe)))
     case t:GroundType => e
     case t => error("Unknown type encountered in toBits!")
@@ -69,7 +69,7 @@ object toBitMask {
     case t => error("Invalid operand expression for toBits!")
   }
   def hiermask(e: Expression, maskType: Type, dataType: Type): Expression = (maskType, dataType) match {
-    case (mt:VectorType, dt:VectorType) => seqCat((0 until mt.size).map(i => hiermask(WSubIndex(e, i, mt.tpe, UNKNOWNGENDER), mt.tpe, dt.tpe)))
+    case (mt:VectorType, dt:VectorType) => seqCat((0 until mt.size).reverse.map(i => hiermask(WSubIndex(e, i, mt.tpe, UNKNOWNGENDER), mt.tpe, dt.tpe)))
     case (mt:BundleType, dt:BundleType) => seqCat((mt.fields zip dt.fields).map{ case (mf,df) =>
       hiermask(WSubField(e, mf.name, mf.tpe, UNKNOWNGENDER), mf.tpe, df.tpe) })
     case (mt:UIntType, dt:GroundType) => seqCat(List.fill(bitWidth(dt).intValue)(e))

--- a/src/main/scala/firrtl/passes/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/MemUtils.scala
@@ -54,7 +54,7 @@ object toBits {
     case t => error("Invalid operand expression for toBits!")
   }
   def hiercat(e: Expression, dt: Type): Expression = dt match {
-    case t:VectorType => seqCat((0 to t.size).map(i => hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER),t.tpe)))
+    case t:VectorType => seqCat((0 until t.size).map(i => hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER),t.tpe)))
     case t:BundleType => seqCat(t.fields.map(f => hiercat(WSubField(e, f.name, f.tpe, UNKNOWNGENDER), f.tpe)))
     case t:GroundType => e
     case t => error("Unknown type encountered in toBits!")
@@ -69,7 +69,7 @@ object toBitMask {
     case t => error("Invalid operand expression for toBits!")
   }
   def hiermask(e: Expression, maskType: Type, dataType: Type): Expression = (maskType, dataType) match {
-    case (mt:VectorType, dt:VectorType) => seqCat((0 to mt.size).map(i => hiermask(WSubIndex(e, i, mt.tpe, UNKNOWNGENDER), mt.tpe, dt.tpe)))
+    case (mt:VectorType, dt:VectorType) => seqCat((0 until mt.size).map(i => hiermask(WSubIndex(e, i, mt.tpe, UNKNOWNGENDER), mt.tpe, dt.tpe)))
     case (mt:BundleType, dt:BundleType) => seqCat((mt.fields zip dt.fields).map{ case (mf,df) =>
       hiermask(WSubField(e, mf.name, mf.tpe, UNKNOWNGENDER), mf.tpe, df.tpe) })
     case (mt:UIntType, dt:GroundType) => seqCat(List.fill(bitWidth(dt).intValue)(e))
@@ -108,7 +108,7 @@ object fromBits {
       case t:VectorType => {
         var currentOffset = offset
         var stmts = Seq.empty[Statement]
-        for (i <- (0 to t.size)) {
+        for (i <- (0 until t.size)) {
           val (tmpOffset, substmts) = getPart(WSubIndex(lhs, i, t.tpe, UNKNOWNGENDER), t.tpe, rhs, currentOffset)
           stmts = stmts ++ substmts
           currentOffset = tmpOffset
@@ -132,28 +132,37 @@ object fromBits {
 }
 
 object MemPortUtils {
-  def rPortToBundle(mem: DefMemory) =
-    BundleType(Seq(
-      Field("data", Flip, mem.dataType),
-      Field("addr", Default, UIntType(IntWidth(ceil_log2(mem.depth)))),
-      Field("en", Default, UIntType(IntWidth(1))),
-      Field("clk", Default, ClockType)))
-  def wPortToBundle(mem: DefMemory) =
-    BundleType(Seq(
-      Field("data", Default, mem.dataType),
-      Field("mask", Default, create_mask(mem.dataType)),
-      Field("addr", Default, UIntType(IntWidth(ceil_log2(mem.depth)))),
-      Field("en", Default, UIntType(IntWidth(1))),
-      Field("clk", Default, ClockType)))
-  def rwPortToBundle(mem: DefMemory) =
-    BundleType(Seq(
+
+  import AnalysisUtils._
+
+  def defaultPortSeq(mem: DefMemory) = Seq(
+    Field("addr", Default, UIntType(IntWidth(ceil_log2(mem.depth)))),
+    Field("en", Default, UIntType(IntWidth(1))),
+    Field("clk", Default, ClockType)
+  )
+
+  def rPortToBundle(mem: DefMemory) = BundleType(defaultPortSeq(mem) :+ Field("data", Flip, mem.dataType))
+
+  def wPortToBundle(mem: DefMemory) = {
+    val defaultSeq = defaultPortSeq(mem) :+ Field("data", Default, mem.dataType)
+    BundleType(
+      if (containsInfo(mem.info,"maskGran")) defaultSeq :+ Field("mask", Default, create_mask(mem.dataType))
+      else defaultSeq
+    )
+  }
+
+  def rwPortToBundle(mem: DefMemory) ={
+    val defaultSeq = defaultPortSeq(mem) ++ Seq(
       Field("wmode", Default, UIntType(IntWidth(1))),
       Field("wdata", Default, mem.dataType),
-      Field("rdata", Flip, mem.dataType),
-      Field("wmask", Default, create_mask(mem.dataType)),
-      Field("addr", Default, UIntType(IntWidth(ceil_log2(mem.depth)))),
-      Field("en", Default, UIntType(IntWidth(1))),
-      Field("clk", Default, ClockType)))
+      Field("rdata", Flip, mem.dataType)
+    )
+    BundleType(
+      if (containsInfo(mem.info,"maskGran")) defaultSeq :+ Field("wmask", Default, create_mask(mem.dataType))
+      else defaultSeq
+    )
+  }
+
   def memToBundle(s: DefMemory) = BundleType(
     s.readers.map(p => Field(p, Default, rPortToBundle(s))) ++
       s.writers.map(p => Field(p, Default, wPortToBundle(s))) ++

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -13,7 +13,13 @@ case object OutputConfigFileName extends PassOption
 case object PassCircuitName extends PassOption
 
 object Error {
-  def apply[T <: Any](msg: String) = throw new Exception(msg)
+  def apply(msg: String) = throw new Exception(msg)
+}
+object Warn {
+  def apply[T <: Any](msg: String, r: T) = {
+    println(Console.RED + msg + Console.RESET)
+    r
+  }
 }
 
 object PassConfigUtil {

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -1,0 +1,276 @@
+package firrtl.passes
+
+import com.typesafe.scalalogging.LazyLogging
+import scala.collection.mutable.{ArrayBuffer,HashMap}
+
+import firrtl._
+import firrtl.ir._
+import firrtl.Mappers._
+import firrtl.Utils._
+import Annotations._
+import firrtl.PrimOps._
+import firrtl.WrappedExpression._
+
+import java.io.Writer
+
+import scala.util.matching.Regex
+
+case class ReplSeqMemAnnotation(t: String, tID: TransID)
+    extends Annotation with Loose with Unstable {
+
+  val usage = """
+[Optional] ReplSeqMem
+  Pass to replace sequential memories with blackboxes + configuration file
+
+Usage: 
+  --replSeqMem -c:<circuit>:-i<filename>:-o<filename>
+  *** Note: sub-arguments to --replSeqMem should be delimited by : and not white space!
+
+Required Arguments:
+  -o<filename>         Specify the output configuration file
+  -c<compiler>         Specify the target circuit
+
+Optional Arguments:
+  -i<filename>         Specify the input configuration file
+"""    
+
+  sealed trait PassOption
+  case object InputConfigFileName extends PassOption
+  case object OutputConfigFileName extends PassOption
+  case object PassCircuitName extends PassOption
+  
+  type PassOptionMap = Map[PassOption, String] 
+
+  // can't use space to delimit sub arguments (otherwise, Driver.scala will throw error)
+  val passArgList = t.split(":").toList
+  
+  def nextPassOption(map: PassOptionMap, list: List[String]): PassOptionMap = {
+    list match {
+      case Nil => map
+      case "-i" :: value :: tail =>
+        nextPassOption(map + (InputConfigFileName -> value), tail)
+      case "-o" :: value :: tail =>
+        nextPassOption(map + (OutputConfigFileName -> value), tail)
+      case "-c" :: value :: tail =>
+        nextPassOption(map + (PassCircuitName -> value), tail)
+      case option :: tail =>
+        throw new Exception("Unknown option " + option + usage)
+    }
+  }
+
+  val passOptions = nextPassOption(Map[PassOption, String](), passArgList)
+  val inputConfig = passOptions.getOrElse(InputConfigFileName, throw new Exception("No input config file provided for ReplSeqMem!" + usage))
+  val outputConfig = passOptions.getOrElse(OutputConfigFileName, throw new Exception("No output config file provided for ReplSeqMem!" + usage))
+  val passCircuit = passOptions.getOrElse(PassCircuitName, throw new Exception("No circuit name specified for ReplSeqMem!" + usage))
+
+  val target = CircuitName(passCircuit)
+  def duplicate(n: Named) = this.copy(t=t.replace("-c:"+passCircuit,"-c:"+n.name))
+  
+}
+
+object ReplSeqMem extends Pass {
+
+  def name = "Replace Sequential Memories with Blackboxes + Configuration File"
+
+  trait WritePortChar {
+    def name: String
+    def useMask: Boolean
+    def maskGran: Option[BigInt]
+    require( (useMask && (maskGran != None)) || (!useMask), "Must specify a mask granularity if write mask is desired" )
+  }
+
+  case class PortForWrite(
+    name: String,
+    useMask: Boolean = false,
+    maskGran: Option[BigInt] = None
+  ) extends WritePortChar 
+
+  case class PortForReadWrite(
+    name: String,
+    useMask: Boolean = false,
+    maskGran: Option[BigInt] = None
+  ) extends WritePortChar 
+
+  case class PortForRead(
+    name: String
+  )
+
+  // vendor agnostic configuration
+  case class SMem(
+    m: DefMemory,
+    // names of read ports
+    readPorts: Seq[PortForRead],
+    // write ports
+    writePorts: Seq[PortForWrite],
+    // read/write ports
+    readWritePorts: Seq[PortForReadWrite]
+  ){
+    require ( 
+      if (readWritePorts.isEmpty) writePorts.nonEmpty && readPorts.nonEmpty else writePorts.isEmpty && readPorts.isEmpty,
+      "Need at least one set of read, write ports if no RW port is specified. A RW port must be standalone"
+    )  
+    require (readWritePorts.length < 2, "Cannot have more than 1 readwrite port")
+    def name = m.name
+    def dataType = m.dataType
+    def depth = m.depth
+    def writeLatency = m.writeLatency
+    def readLatency = m.readLatency
+    def numReaders = readPorts.length
+    def numWriters = writePorts.length
+    def numRWriters = readWritePorts.length  
+    def rPortMap = readPorts.zipWithIndex map { case (p,i) => p -> s"R$i" }
+    def wPortMap = writePorts.zipWithIndex map { case (p,i) => p.name -> s"W$i" }
+    def rwPortMap = readWritePorts.zipWithIndex map { case (p,i) => p.name -> s"RW$i" }
+    def width = bitWidth(dataType)
+    def serialize = {
+      // for backwards compatibility with old conf format
+      val writers = writePorts map (x => if (x.useMask) "mwrite" else "write")
+      val readers = List.fill(numReaders)("read")
+      val readwriters = readWritePorts map (x => if(x.useMask) "mrw" else "rw")
+      val ports = (writers ++ readers ++ readwriters).mkString(",")
+      // old conf file only supported 1 mask_gran
+      val maskGran = (writePorts ++ readWritePorts) map (_.maskGran.getOrElse(0))
+      val maskGranConf = if (maskGran.head == 0) "" else s"mask_gran ${maskGran.head}"
+      s"name ${name} depth ${depth} width ${width} ports ${ports} ${maskGranConf} \n"
+    }
+    def eq(m: SMem) = {
+      // TODO: Condition on read under write
+      val wpIndivEq = writePorts zip m.writePorts map {case(a,b) => a.maskGran == b.maskGran} 
+      val wpEq = wpIndivEq.foldLeft(true)(_ && _)
+      val rwpIndivEq = readWritePorts zip m.readWritePorts map {case(a,b) => a.maskGran == b.maskGran} 
+      val rwpEq = rwpIndivEq.foldLeft(true)(_ && _)
+      (dataType == m.dataType) && 
+      (depth == m.depth) && 
+      (writeLatency == m.writeLatency) && 
+      (readLatency == m.readLatency) && 
+      (numReaders == m.numReaders) && 
+      (wpEq && rwpEq)
+    }
+  }
+
+  def analyzeMemsInModule(m: Module): Seq[SMem] = {
+
+    val connects = HashMap[String, Expression]()
+    val mems = ArrayBuffer[SMem]()
+
+    // swiped from InferRW 
+    def findConnects(s: Statement): Unit = s match {
+      case s: Connect  =>
+        connects(s.loc.serialize) = s.expr
+      case s: PartialConnect =>
+        connects(s.loc.serialize) = s.expr
+      case s: DefNode =>
+        connects(s.name) = s.value
+      case s: Block =>
+        s.stmts foreach findConnects
+      case _ =>
+    }
+
+    def findConnectOriginFromExp(e: Expression): Seq[Expression] = e match {
+      // matches how wmode, wmask, write_en are assigned (from Chirrtl) 
+      // in case no ConstProp is performed before this pass
+      case Mux(cond, tv, fv, _) if we(tv) == we(one) && we(fv) == we(zero) =>
+        cond +: findConnectOrigin(cond.serialize)
+      // visit connected nodes to references
+      case _: WRef | _: SubField | _: SubIndex | _: SubAccess =>
+        e +: findConnectOrigin(e.serialize) 
+      // backward searches until a PrimOp or Literal appears -->
+      // Literal: you've reached origin
+      // PrimOp: you're not simply doing propagation anymore
+      // NOTE: not a catch-all!!! 
+      case _ => List(e)  
+    }
+
+    // only capable of searching for origin in the same module
+    def findConnectOrigin(node: String): Seq[Expression] = {
+      if (connects contains node) findConnectOriginFromExp(connects(node))
+      else Nil
+    }
+
+    // returns None if wen = wmask bits or wmask bits all = 1; otherwise returns # of mask bits
+    def getMaskBits(wen: String, wmask: String): Option[Int] = {
+      val wenOrigin = findConnectOrigin(wen)
+      // find all mask bits
+      val wmaskOrigin = connects.keys.toSeq filter (_.startsWith(wmask)) map findConnectOrigin
+      val bitEq = wmaskOrigin map (wenOrigin intersect _) map (_.length > 0) 
+      // when all wmask bits are equal to wmode, wmask is redundant
+      val eq = bitEq.foldLeft(true)(_ && _)
+      val wmaskBitOne = wmaskOrigin map(_ contains one)
+      // if all wmask bits = 1, then wmask is redundant
+      val wmaskOne = wmaskBitOne.foldLeft(true)(_ && _)
+      if (eq || wmaskOne) None else Some(wmaskOrigin.length)
+    }
+
+    def findMemInsts(s: Statement): Unit = s match {
+      // only find smems
+      case m: DefMemory if m.readLatency > 0 =>
+        val dataBits = bitWidth(m.dataType)
+        val rwPorts = m.readwriters map (w => {
+          val maskBits = getMaskBits(s"${m.name}.$w.wmode",s"${m.name}.$w.wmask")
+          if (maskBits == None) PortForReadWrite(name = w)
+          else PortForReadWrite(name = w, useMask = true, maskGran = Some(dataBits/maskBits.get))
+        })
+        val wPorts = m.writers map (w => {
+          val maskBits = getMaskBits(s"${m.name}.$w.en",s"${m.name}.$w.mask")
+          if (maskBits == None) PortForWrite(name = w)
+          else PortForWrite(name = w, useMask = true, maskGran = Some(dataBits/maskBits.get))  
+        })
+        val smemInfo = SMem(
+          m = m,
+          readPorts = m.readers map(r => PortForRead(name = r)),
+          writePorts = wPorts,
+          readWritePorts = rwPorts
+        )
+        mems += smemInfo
+      case b: Block => b.stmts foreach findMemInsts
+      case _ => 
+    }
+    findConnects(m.body)
+    findMemInsts(m.body)
+    mems.toSeq
+  }
+
+  def run(c: Circuit) = {
+    val uniqueMems = ArrayBuffer[SMem]()
+    def analyzeMemsInCircuit(c: Circuit) = {
+      val mems = ArrayBuffer[SMem]()
+      c.modules foreach { _ match {
+        case m: Module => mems ++= analyzeMemsInModule(m)
+        case m: ExtModule =>
+      }}
+      mems map {m =>
+        val memProto = uniqueMems.find(_.eq(m))
+        if (memProto == None) {
+          uniqueMems += m
+          m.name -> m
+        }
+        else m.name -> memProto.get.copy(m=m.m)
+      }
+    }
+    val memMap = analyzeMemsInCircuit(c)
+    println(memMap)
+    c
+  }
+
+}
+
+class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
+  def execute(circuit:Circuit, map: AnnotationMap) = 
+    map get transID match {
+      case Some(p) => p get CircuitName(circuit.main) match {
+        case Some(ReplSeqMemAnnotation(_, _)) => TransformResult((Seq(
+          Legalize,
+          ReplSeqMem,
+          CheckInitialization,
+          ResolveKinds,
+          InferTypes,
+          ResolveGenders) foldLeft circuit){ (c, pass) =>
+            val x = Utils.time(pass.name)(pass run c)
+            logger debug x.serialize
+            x
+          }, None, Some(map))
+        case _ => TransformResult(circuit, None, Some(map))
+      }
+      case _ => TransformResult(circuit, None, Some(map))
+    }
+}

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -103,7 +103,6 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
             (
               Seq(
                 Legalize,
-                ExpandWhens,
                 AnnotateMemMacros,
                 UpdateDuplicateMemMacros,
                 new ReplaceMemMacros(outConfigFile),

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -50,7 +50,7 @@ class ConfWriter(filename: String) {
     val ports = (writers ++ readers ++ readwriters).mkString(",")
     val maskGranConf = if (maskGran == None) "" else s"mask_gran ${maskGran.get}"
     val width = bitWidth(m.dataType)
-    val conf = s"name ${m.name} depth ${m.depth} width ${width} ports ${ports} ${maskGranConf} \n"
+    val conf = s"name ${m.name}_ext depth ${m.depth} width ${width} ports ${ports} ${maskGranConf} \n"
     outputBuffer.append(conf)
   }
   def serialize = {

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package firrtl.passes
 
 import com.typesafe.scalalogging.LazyLogging
@@ -43,7 +45,7 @@ class ConfWriter(filename: String) {
   val outputBuffer = new java.io.CharArrayWriter
   def append(m: DefMemory) = {
     // legacy
-    val maskGran = getInfo(m.info,"maskGran")
+    val maskGran = getInfo(m.info, "maskGran")
     val writers = m.writers map (x => if (maskGran == None) "write" else "mwrite")
     val readers = List.fill(m.readers.length)("read")
     val readwriters = m.readwriters map (x => if (maskGran == None) "rw" else "mrw")
@@ -79,7 +81,7 @@ Optional Arguments:
   -i<filename>         Specify the input configuration file (for additional optimizations)
 """    
 
-  val passOptions = PassConfigUtil.getPassOptions(t,usage)
+  val passOptions = PassConfigUtil.getPassOptions(t, usage)
   val outputConfig = passOptions.getOrElse(
     OutputConfigFileName, 
     error("No output config file provided for ReplSeqMem!" + usage)
@@ -89,7 +91,7 @@ Optional Arguments:
     error("No circuit name specified for ReplSeqMem!" + usage)
   )
   val target = CircuitName(passCircuit)
-  def duplicate(n: Named) = this.copy(t=t.replace("-c:"+passCircuit,"-c:"+n.name))
+  def duplicate(n: Named) = this.copy(t=t.replace("-c:"+passCircuit, "-c:"+n.name))
   
 }
 
@@ -99,7 +101,7 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
       case Some(p) => p get CircuitName(circuit.main) match {
         case Some(ReplSeqMemAnnotation(t, _)) => {
 
-          val inputFileName = PassConfigUtil.getPassOptions(t).getOrElse(InputConfigFileName,"")
+          val inputFileName = PassConfigUtil.getPassOptions(t).getOrElse(InputConfigFileName, "")
           val inConfigFile = {
             if (inputFileName.isEmpty) None 
             else if (new java.io.File(inputFileName).exists) Some(new YamlFileReader(inputFileName))
@@ -121,12 +123,12 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
                 InferTypes,
                 ResolveGenders
               ) foldLeft circuit
-            ){ 
+            ) { 
               (c, pass) =>
                 val x = Utils.time(pass.name)(pass run c)
                 logger debug x.serialize
                 x
-            }, 
+            } , 
             None, 
             Some(map)
           )

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -1,19 +1,11 @@
 package firrtl.passes
 
 import com.typesafe.scalalogging.LazyLogging
-import scala.collection.mutable.{ArrayBuffer,HashMap}
-
 import firrtl._
 import firrtl.ir._
-import firrtl.Mappers._
-import firrtl.Utils._
 import Annotations._
-import firrtl.PrimOps._
-import firrtl.WrappedExpression._
-
 import java.io.Writer
-
-import scala.util.matching.Regex
+import AnalysisUtils._
 
 sealed trait PassOption
 case object InputConfigFileName extends PassOption
@@ -47,9 +39,20 @@ object PassConfigUtil {
 
 }
 
-class OutputWriter(filename: String) {
+class ConfWriter(filename: String) {
   val outputBuffer = new java.io.CharArrayWriter
-  def append(s: String) = outputBuffer.append(s)
+  def append(m: DefMemory) = {
+    // legacy
+    val maskGran = getInfo(m.info,"maskGran")
+    val writers = m.writers map (x => if (maskGran == None) "write" else "mwrite")
+    val readers = List.fill(m.readers.length)("read")
+    val readwriters = m.readwriters map (x => if (maskGran == None) "rw" else "mrw")
+    val ports = (writers ++ readers ++ readwriters).mkString(",")
+    val maskGranConf = if (maskGran == None) "" else s"mask_gran ${maskGran.get}"
+    val width = bitWidth(m.dataType)
+    val conf = s"name ${m.name} depth ${m.depth} width ${width} ports ${ports} ${maskGranConf} \n"
+    outputBuffer.append(conf)
+  }
   def serialize = {
     val outputFile = new java.io.PrintWriter(filename)
     outputFile.write(outputBuffer.toString)
@@ -73,226 +76,21 @@ Required Arguments:
   -c<compiler>         Specify the target circuit
 
 Optional Arguments:
-  -i<filename>         Specify the input configuration file
+  -i<filename>         Specify the input configuration file (for additional optimizations)
 """    
 
   val passOptions = PassConfigUtil.getPassOptions(t,usage)
-  val outputConfig = passOptions.getOrElse(OutputConfigFileName, throw new Exception("No output config file provided for ReplSeqMem!" + usage))
-  val passCircuit = passOptions.getOrElse(PassCircuitName, throw new Exception("No circuit name specified for ReplSeqMem!" + usage))
+  val outputConfig = passOptions.getOrElse(
+    OutputConfigFileName, 
+    throw new Exception("No output config file provided for ReplSeqMem!" + usage)
+  )
+  val passCircuit = passOptions.getOrElse(
+    PassCircuitName, 
+    throw new Exception("No circuit name specified for ReplSeqMem!" + usage)
+  )
   val target = CircuitName(passCircuit)
   def duplicate(n: Named) = this.copy(t=t.replace("-c:"+passCircuit,"-c:"+n.name))
   
-}
-
-class ReplSeqMemPass(out: OutputWriter) extends Pass {
-
-  def name = "Replace Sequential Memories with Blackboxes + Configuration File"
-
-  trait WritePortChar {
-    def name: String
-    def useMask: Boolean
-    def maskGran: Option[BigInt]
-    require( (useMask && (maskGran != None)) || (!useMask), "Must specify a mask granularity if write mask is desired" )
-  }
-
-  case class PortForWrite(
-    name: String,
-    useMask: Boolean = false,
-    maskGran: Option[BigInt] = None
-  ) extends WritePortChar 
-
-  case class PortForReadWrite(
-    name: String,
-    useMask: Boolean = false,
-    maskGran: Option[BigInt] = None
-  ) extends WritePortChar 
-
-  case class PortForRead(
-    name: String
-  )
-
-  // vendor agnostic configuration
-  case class SMem(
-    m: DefMemory,
-    // names of read ports
-    readPorts: Seq[PortForRead],
-    // write ports
-    writePorts: Seq[PortForWrite],
-    // read/write ports
-    readWritePorts: Seq[PortForReadWrite]
-  ){
-    require ( 
-      if (readWritePorts.isEmpty) writePorts.nonEmpty && readPorts.nonEmpty else writePorts.isEmpty && readPorts.isEmpty,
-      "Need at least one set of read, write ports if no RW port is specified. A RW port must be standalone"
-    )  
-    require (readWritePorts.length < 2, "Cannot have more than 1 readwrite port")
-    def name = m.name
-    def dataType = m.dataType
-    def depth = m.depth
-    def writeLatency = m.writeLatency
-    def readLatency = m.readLatency
-    def numReaders = readPorts.length
-    def numWriters = writePorts.length
-    def numRWriters = readWritePorts.length  
-    def rPortMap = readPorts.zipWithIndex map { case (p,i) => p -> s"R$i" }
-    def wPortMap = writePorts.zipWithIndex map { case (p,i) => p.name -> s"W$i" }
-    def rwPortMap = readWritePorts.zipWithIndex map { case (p,i) => p.name -> s"RW$i" }
-    def width = bitWidth(dataType)
-    def serialize = {
-      // for backwards compatibility with old conf format
-      val writers = writePorts map (x => if (x.useMask) "mwrite" else "write")
-      val readers = List.fill(numReaders)("read")
-      val readwriters = readWritePorts map (x => if(x.useMask) "mrw" else "rw")
-      val ports = (writers ++ readers ++ readwriters).mkString(",")
-      // old conf file only supported 1 mask_gran
-      val maskGran = (writePorts ++ readWritePorts) map (_.maskGran.getOrElse(0))
-      val maskGranConf = if (maskGran.head == 0) "" else s"mask_gran ${maskGran.head}"
-      s"name ${name} depth ${depth} width ${width} ports ${ports} ${maskGranConf} \n"
-    }
-    def eq(m: SMem) = {
-      // TODO: Condition on read under write
-      val wpIndivEq = writePorts zip m.writePorts map {case(a,b) => a.maskGran == b.maskGran} 
-      val wpEq = wpIndivEq.foldLeft(true)(_ && _)
-      val rwpIndivEq = readWritePorts zip m.readWritePorts map {case(a,b) => a.maskGran == b.maskGran} 
-      val rwpEq = rwpIndivEq.foldLeft(true)(_ && _)
-      (dataType == m.dataType) && 
-      (depth == m.depth) && 
-      (writeLatency == m.writeLatency) && 
-      (readLatency == m.readLatency) && 
-      (numReaders == m.numReaders) && 
-      (wpEq && rwpEq)
-    }
-    def getInterfacePorts = MemPortUtils.memToBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe))
-  }
-
-  def analyzeMemsInModule(m: Module): Seq[SMem] = {
-
-    val connects = HashMap[String, Expression]()
-    val mems = ArrayBuffer[SMem]()
-
-    // swiped from InferRW 
-    def findConnects(s: Statement): Unit = s match {
-      case s: Connect  =>
-        connects(s.loc.serialize) = s.expr
-      case s: PartialConnect =>
-        connects(s.loc.serialize) = s.expr
-      case s: DefNode =>
-        connects(s.name) = s.value
-      case s: Block =>
-        s.stmts foreach findConnects
-      case _ =>
-    }
-
-    def findConnectOriginFromExp(e: Expression): Seq[Expression] = e match {
-      // matches how wmode, wmask, write_en are assigned (from Chirrtl) 
-      // in case no ConstProp is performed before this pass
-      case Mux(cond, tv, fv, _) if we(tv) == we(one) && we(fv) == we(zero) =>
-        cond +: findConnectOrigin(cond.serialize)
-      // visit connected nodes to references
-      case _: WRef | _: SubField | _: SubIndex | _: SubAccess =>
-        e +: findConnectOrigin(e.serialize) 
-      // backward searches until a PrimOp or Literal appears -->
-      // Literal: you've reached origin
-      // PrimOp: you're not simply doing propagation anymore
-      // NOTE: not a catch-all!!! 
-      case _ => List(e)  
-    }
-
-    // only capable of searching for origin in the same module
-    def findConnectOrigin(node: String): Seq[Expression] = {
-      if (connects contains node) findConnectOriginFromExp(connects(node))
-      else Nil
-    }
-
-    // returns None if wen = wmask bits or wmask bits all = 1; otherwise returns # of mask bits
-    def getMaskBits(wen: String, wmask: String): Option[Int] = {
-      val wenOrigin = findConnectOrigin(wen)
-      // find all mask bits
-      val wmaskOrigin = connects.keys.toSeq filter (_.startsWith(wmask)) map findConnectOrigin
-      val bitEq = wmaskOrigin map (wenOrigin intersect _) map (_.length > 0) 
-      // when all wmask bits are equal to wmode, wmask is redundant
-      val eq = bitEq.foldLeft(true)(_ && _)
-      val wmaskBitOne = wmaskOrigin map(_ contains one)
-      // if all wmask bits = 1, then wmask is redundant
-      val wmaskOne = wmaskBitOne.foldLeft(true)(_ && _)
-      if (eq || wmaskOne) None else Some(wmaskOrigin.length)
-    }
-
-    def findMemInsts(s: Statement): Unit = s match {
-      // only find smems
-      case m: DefMemory if m.readLatency > 0 =>
-        val dataBits = bitWidth(m.dataType)
-        val rwPorts = m.readwriters map (w => {
-          val maskBits = getMaskBits(s"${m.name}.$w.wmode",s"${m.name}.$w.wmask")
-          if (maskBits == None) PortForReadWrite(name = w)
-          else PortForReadWrite(name = w, useMask = true, maskGran = Some(dataBits/maskBits.get))
-        })
-        val wPorts = m.writers map (w => {
-          val maskBits = getMaskBits(s"${m.name}.$w.en",s"${m.name}.$w.mask")
-          if (maskBits == None) PortForWrite(name = w)
-          else PortForWrite(name = w, useMask = true, maskGran = Some(dataBits/maskBits.get))  
-        })
-        val smemInfo = SMem(
-          m = m,
-          readPorts = m.readers map(r => PortForRead(name = r)),
-          writePorts = wPorts,
-          readWritePorts = rwPorts
-        )
-        mems += smemInfo
-      case b: Block => b.stmts foreach findMemInsts
-      case _ => 
-    }
-    findConnects(m.body)
-    findMemInsts(m.body)
-    mems.toSeq
-  }
-
-  def run(c: Circuit) = {
-    lazy val moduleNamespace = Namespace(c)
-
-    val uniqueMems = ArrayBuffer[SMem]()
-    val mems = ArrayBuffer[SMem]()
-    def analyzeMemsInCircuit(c: Circuit) = {
-      c.modules foreach { 
-        case m: Module => mems ++= analyzeMemsInModule(m)
-        case m: ExtModule =>
-      }
-      mems map {m =>
-        val memProto = uniqueMems.find(_.eq(m))
-        if (memProto == None) {
-          uniqueMems += m
-          m.name -> m
-        }
-        else m.name -> memProto.get.copy(m=m.m)
-      }
-    }
-    val memMap = analyzeMemsInCircuit(c)
-    val newMods = mems map (m => ExtModule(m.m.info,m.name,m.getInterfacePorts)) 
-
-    def replaceMemInstsInCircuit(c: Circuit) = {
-      def replaceMemInstsInModule(m: Module) = {
-        def findMemInsts(s: Statement): Statement = s match {
-          case m: DefMemory if m.readLatency > 0 =>  WDefInstance(m.info, m.name, m.name, UnknownType) 
-          case b: Block => Block(b.stmts map findMemInsts)
-          case s => s
-        }
-        m.copy(body = findMemInsts(m.body))
-      }
-      c.modules map {
-        case m: Module => replaceMemInstsInModule(m)
-        case m: ExtModule => m
-      } 
-    } 
-
-    uniqueMems foreach { m =>
-      moduleNamespace.newName(m.name)
-      moduleNamespace.newName(m.name + "_ext")
-      out.append(m.serialize)
-    }
-    out.serialize
-    c.copy(modules = replaceMemInstsInCircuit(c) ++ newMods)
-  }
-
 }
 
 class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
@@ -300,12 +98,14 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
     map get transID match {
       case Some(p) => p get CircuitName(circuit.main) match {
         case Some(ReplSeqMemAnnotation(t, _)) => {
-          val outConfigFile = PassConfigUtil.getPassOptions(t).get(OutputConfigFileName).get
+          val outConfigFile = new ConfWriter(PassConfigUtil.getPassOptions(t).get(OutputConfigFileName).get)
           TransformResult(
             (
               Seq(
                 Legalize,
-                new ReplSeqMemPass(new OutputWriter(outConfigFile)),
+                AnnotateMemMacros,
+                UpdateDuplicateMemMacros,
+                new ReplaceMemMacros(outConfigFile),
                 RemoveEmpty,
                 CheckInitialization,
                 ResolveKinds,                                       // Must be run for the transform to work!
@@ -327,7 +127,3 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
       case _ => TransformResult(circuit, None, Some(map))
     }
 }
-
-// Eliminate extra modules
-// Tag modules
-// connect internals

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -103,6 +103,7 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
             (
               Seq(
                 Legalize,
+                ExpandWhens,
                 AnnotateMemMacros,
                 UpdateDuplicateMemMacros,
                 new ReplaceMemMacros(outConfigFile),

--- a/src/main/scala/firrtl/passes/ReplSeqMem.scala
+++ b/src/main/scala/firrtl/passes/ReplSeqMem.scala
@@ -12,16 +12,6 @@ case object InputConfigFileName extends PassOption
 case object OutputConfigFileName extends PassOption
 case object PassCircuitName extends PassOption
 
-object Error {
-  def apply(msg: String) = throw new Exception(msg)
-}
-object Warn {
-  def apply[T <: Any](msg: String, r: T) = {
-    println(Console.RED + msg + Console.RESET)
-    r
-  }
-}
-
 object PassConfigUtil {
 
   def getPassOptions(t: String, usage: String = "") = {
@@ -41,7 +31,7 @@ object PassConfigUtil {
         case "-c" :: value :: tail =>
           nextPassOption(map + (PassCircuitName -> value), tail)
         case option :: tail =>
-          Error("Unknown option " + option + usage)
+          error("Unknown option " + option + usage)
       }
     }
     nextPassOption(Map[PassOption, String](), passArgList)
@@ -92,11 +82,11 @@ Optional Arguments:
   val passOptions = PassConfigUtil.getPassOptions(t,usage)
   val outputConfig = passOptions.getOrElse(
     OutputConfigFileName, 
-    Error("No output config file provided for ReplSeqMem!" + usage)
+    error("No output config file provided for ReplSeqMem!" + usage)
   )
   val passCircuit = passOptions.getOrElse(
     PassCircuitName, 
-    Error("No circuit name specified for ReplSeqMem!" + usage)
+    error("No circuit name specified for ReplSeqMem!" + usage)
   )
   val target = CircuitName(passCircuit)
   def duplicate(n: Named) = this.copy(t=t.replace("-c:"+passCircuit,"-c:"+n.name))
@@ -113,7 +103,7 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
           val inConfigFile = {
             if (inputFileName.isEmpty) None 
             else if (new java.io.File(inputFileName).exists) Some(new YamlFileReader(inputFileName))
-            else Error("Input configuration file does not exist!")
+            else error("Input configuration file does not exist!")
           }
 
           val outConfigFile = new ConfWriter(PassConfigUtil.getPassOptions(t).get(OutputConfigFileName).get)
@@ -141,7 +131,7 @@ class ReplSeqMem(transID: TransID) extends Transform with LazyLogging {
             Some(map)
           )
         }  
-        case _ => TransformResult(circuit, None, Some(map))
+        case _ => error("Unexpected transform annotation")
       }
       case _ => TransformResult(circuit, None, Some(map))
     }

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -1,6 +1,8 @@
+// See LICENSE for license details.
+
 package firrtl.passes
 
-import scala.collection.mutable.{HashMap,ArrayBuffer}
+import scala.collection._
 import firrtl.ir._
 import AnalysisUtils._
 import MemTransformUtils._
@@ -16,33 +18,33 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
   def run(c: Circuit) = {
 
     lazy val moduleNamespace = Namespace(c)
-    val memMods = ArrayBuffer[DefModule]()
-    val uniqueMems = ArrayBuffer[DefMemory]()
+    val memMods = mutable.ArrayBuffer[DefModule]()
+    val uniqueMems = mutable.ArrayBuffer[DefMemory]()
 
     def updateMemMods(m: Module) = {
-      val memPortMap = HashMap[String,Expression]()
+      val memPortMap = mutable.HashMap[String, Expression]()
 
       def updateMemStmts(s: Statement): Statement = s match {
-        case m: DefMemory if containsInfo(m.info,"useMacro") => 
-          if(!containsInfo(m.info,"maskGran")) {
-            m.writers foreach {w => memPortMap(s"${m.name}.${w}.mask") = EmptyExpression}
-            m.readwriters foreach {w => memPortMap(s"${m.name}.${w}.wmask") = EmptyExpression}
+        case m: DefMemory if containsInfo(m.info, "useMacro") => 
+          if(!containsInfo(m.info, "maskGran")) {
+            m.writers foreach { w => memPortMap(s"${m.name}.${w}.mask") = EmptyExpression }
+            m.readwriters foreach { w => memPortMap(s"${m.name}.${w}.wmask") = EmptyExpression }
           }
-          val infoT = getInfo(m.info,"info")
-          val info = if (infoT == None) NoInfo else infoT.get match {case i: Info => i}
-          val ref = getInfo(m.info,"ref")
+          val infoT = getInfo(m.info, "info")
+          val info = if (infoT == None) NoInfo else infoT.get match { case i: Info => i }
+          val ref = getInfo(m.info, "ref")
           
           // prototype mem
           if (ref == None) {
             val newWrapperName = moduleNamespace.newName(m.name)
             val newMemBBName = moduleNamespace.newName(m.name + "_ext")
             val newMem = m.copy(name = newMemBBName)
-            memMods ++= createMemModule(newMem,newWrapperName)
+            memMods ++= createMemModule(newMem, newWrapperName)
             uniqueMems += newMem
             WDefInstance(info, m.name, newWrapperName, UnknownType) 
           }
           else {
-            val r = ref.get match {case s: String => s}
+            val r = ref.get match { case s: String => s }
             WDefInstance(info, m.name, r, UnknownType) 
           }
         case b: Block => b map updateMemStmts
@@ -50,7 +52,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
       }
 
       val updatedMems = updateMemStmts(m.body)
-      val updatedConns = updateStmtRefs(updatedMems,memPortMap.toMap)
+      val updatedConns = updateStmtRefs(updatedMems, memPortMap.toMap)
       m.copy(body = updatedConns)
     }
 
@@ -67,64 +69,64 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
   // from Albert
   def createMemModule(m: DefMemory, wrapperName: String): Seq[DefModule] = {
     assert(m.dataType != UnknownType)
-    val stmts = ArrayBuffer[Statement]()
+    val stmts = mutable.ArrayBuffer[Statement]()
     val wrapperioPorts = MemPortUtils.memToBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
     val bbProto = m.copy(dataType = flattenType(m.dataType))
     val bbioPorts = MemPortUtils.memToFlattenBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
 
-    stmts += WDefInstance(NoInfo,m.name,m.name,UnknownType)
+    stmts += WDefInstance(NoInfo, m.name, m.name, UnknownType)
     val bbRef = createRef(m.name)
-    stmts ++= (m.readers zip bbProto.readers).map{ 
-      case (x,y) => adaptReader(createRef(x),m,createSubField(bbRef,y),bbProto)
-    }.flatten 
-    stmts ++= (m.writers zip bbProto.writers).map{ 
-      case (x,y) => adaptWriter(createRef(x),m,createSubField(bbRef,y),bbProto)
-    }.flatten 
-    stmts ++= (m.readwriters zip bbProto.readwriters).map{ 
-      case (x,y) => adaptReadWriter(createRef(x),m,createSubField(bbRef,y),bbProto)
-    }.flatten  
-    val wrapper = Module(NoInfo,wrapperName,wrapperioPorts,Block(stmts))   
-    val bb = ExtModule(NoInfo,m.name,bbioPorts) 
+    stmts ++= (m.readers zip bbProto.readers).flatMap { 
+      case (x, y) => adaptReader(createRef(x), m, createSubField(bbRef, y), bbProto)
+    }
+    stmts ++= (m.writers zip bbProto.writers).flatMap { 
+      case (x, y) => adaptWriter(createRef(x), m, createSubField(bbRef, y), bbProto)
+    }
+    stmts ++= (m.readwriters zip bbProto.readwriters).flatMap { 
+      case (x, y) => adaptReadWriter(createRef(x), m, createSubField(bbRef, y), bbProto)
+    } 
+    val wrapper = Module(NoInfo, wrapperName, wrapperioPorts, Block(stmts))   
+    val bb = ExtModule(NoInfo, m.name, bbioPorts) 
     // TODO: Annotate? -- use actual annotation map
 
     // add to conf file
     writer.append(m)
-    Seq(bb,wrapper)
+    Seq(bb, wrapper)
   }
 
   // TODO: get rid of copy pasta
   def adaptReader(wrapperPort: Expression, wrapperMem: DefMemory, bbPort: Expression, bbMem: DefMemory) = Seq(
-    connectFields(bbPort,"addr",wrapperPort,"addr"),
-    connectFields(bbPort,"en",wrapperPort,"en"),
-    connectFields(bbPort,"clk",wrapperPort,"clk"),
+    connectFields(bbPort, "addr", wrapperPort, "addr"),
+    connectFields(bbPort, "en", wrapperPort, "en"),
+    connectFields(bbPort, "clk", wrapperPort, "clk"),
     fromBits(
-      WSubField(wrapperPort,"data",wrapperMem.dataType,UNKNOWNGENDER),
-      WSubField(bbPort,"data",bbMem.dataType,UNKNOWNGENDER)
+      WSubField(wrapperPort, "data", wrapperMem.dataType, UNKNOWNGENDER),
+      WSubField(bbPort, "data", bbMem.dataType, UNKNOWNGENDER)
     )
   )
 
   def adaptWriter(wrapperPort: Expression, wrapperMem: DefMemory, bbPort: Expression, bbMem: DefMemory) = {
     val defaultSeq = Seq(
-      connectFields(bbPort,"addr",wrapperPort,"addr"),
-      connectFields(bbPort,"en",wrapperPort,"en"),
-      connectFields(bbPort,"clk",wrapperPort,"clk"),
+      connectFields(bbPort, "addr", wrapperPort, "addr"),
+      connectFields(bbPort, "en", wrapperPort, "en"),
+      connectFields(bbPort, "clk", wrapperPort, "clk"),
       Connect(
         NoInfo,
-        WSubField(bbPort,"data",bbMem.dataType,UNKNOWNGENDER),
-        toBits(WSubField(wrapperPort,"data",wrapperMem.dataType,UNKNOWNGENDER))
+        WSubField(bbPort, "data", bbMem.dataType, UNKNOWNGENDER),
+        toBits(WSubField(wrapperPort, "data", wrapperMem.dataType, UNKNOWNGENDER))
       )
     )
-    if (containsInfo(wrapperMem.info,"maskGran")) {
+    if (containsInfo(wrapperMem.info, "maskGran")) {
       val wrapperMask = create_mask(wrapperMem.dataType)
       val fillWMask = getFillWMask(wrapperMem)
       val bbMask = if (fillWMask) flattenType(wrapperMem.dataType) else flattenType(wrapperMask)
       val rhs = {
-        if (fillWMask) toBitMask(WSubField(wrapperPort,"mask",wrapperMask,UNKNOWNGENDER),wrapperMem.dataType)
-        else toBits(WSubField(wrapperPort,"mask",wrapperMask,UNKNOWNGENDER))
+        if (fillWMask) toBitMask(WSubField(wrapperPort, "mask", wrapperMask, UNKNOWNGENDER), wrapperMem.dataType)
+        else toBits(WSubField(wrapperPort, "mask", wrapperMask, UNKNOWNGENDER))
       }
       defaultSeq :+ Connect(
         NoInfo,
-        WSubField(bbPort,"mask",bbMask,UNKNOWNGENDER),
+        WSubField(bbPort, "mask", bbMask, UNKNOWNGENDER),
         rhs
       )
     }
@@ -133,31 +135,31 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
 
   def adaptReadWriter(wrapperPort: Expression, wrapperMem: DefMemory, bbPort: Expression, bbMem: DefMemory) = {
     val defaultSeq = Seq(
-      connectFields(bbPort,"addr",wrapperPort,"addr"),
-      connectFields(bbPort,"en",wrapperPort,"en"),
-      connectFields(bbPort,"clk",wrapperPort,"clk"),
-      connectFields(bbPort,"wmode",wrapperPort,"wmode"),
+      connectFields(bbPort, "addr", wrapperPort, "addr"),
+      connectFields(bbPort, "en", wrapperPort, "en"),
+      connectFields(bbPort, "clk", wrapperPort, "clk"),
+      connectFields(bbPort, "wmode", wrapperPort, "wmode"),
       Connect(
         NoInfo,
-        WSubField(bbPort,"wdata",bbMem.dataType,UNKNOWNGENDER),
-        toBits(WSubField(wrapperPort,"wdata",wrapperMem.dataType,UNKNOWNGENDER))
+        WSubField(bbPort, "wdata", bbMem.dataType, UNKNOWNGENDER),
+        toBits(WSubField(wrapperPort, "wdata", wrapperMem.dataType, UNKNOWNGENDER))
       ),
       fromBits(
-        WSubField(wrapperPort,"rdata",wrapperMem.dataType,UNKNOWNGENDER),
-        WSubField(bbPort,"rdata",bbMem.dataType,UNKNOWNGENDER)
+        WSubField(wrapperPort, "rdata", wrapperMem.dataType, UNKNOWNGENDER),
+        WSubField(bbPort, "rdata", bbMem.dataType, UNKNOWNGENDER)
       )
     )
-    if (containsInfo(wrapperMem.info,"maskGran")) {
+    if (containsInfo(wrapperMem.info, "maskGran")) {
       val wrapperMask = create_mask(wrapperMem.dataType)
       val fillWMask = getFillWMask(wrapperMem)
       val bbMask = if (fillWMask) flattenType(wrapperMem.dataType) else flattenType(wrapperMask)
       val rhs = {
-        if (fillWMask) toBitMask(WSubField(wrapperPort,"wmask",wrapperMask,UNKNOWNGENDER),wrapperMem.dataType)
-        else toBits(WSubField(wrapperPort,"wmask",wrapperMask,UNKNOWNGENDER))
+        if (fillWMask) toBitMask(WSubField(wrapperPort, "wmask", wrapperMask, UNKNOWNGENDER), wrapperMem.dataType)
+        else toBits(WSubField(wrapperPort, "wmask", wrapperMask, UNKNOWNGENDER))
       }
       defaultSeq :+ Connect(
         NoInfo,
-        WSubField(bbPort,"wmask",bbMask,UNKNOWNGENDER),
+        WSubField(bbPort, "wmask", bbMask, UNKNOWNGENDER),
         rhs
       )
     }

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -1,0 +1,143 @@
+package firrtl.passes
+
+import scala.collection.mutable.{HashMap,ArrayBuffer}
+import firrtl.ir._
+import AnalysisUtils._
+import MemTransformUtils._
+import firrtl._
+import firrtl.Utils._
+
+object ReplaceMemMacros extends Pass {
+
+  def name = "Replace memories with black box wrappers (optimizes when write mask isn't needed)"
+
+  def run(c: Circuit) = {
+
+    lazy val moduleNamespace = Namespace(c)
+    val memMods = ArrayBuffer[DefModule]()
+    val uniqueMems = ArrayBuffer[DefMemory]()
+
+    def updateMemMods(m: Module) = {
+      val memPortMap = HashMap[String,Expression]()
+
+      def updateMemStmts(s: Statement): Statement = s match {
+        case m: DefMemory if containsInfo(m.info,"useMacro") => 
+          if(!containsInfo(m.info,"maskGran")) {
+            m.writers foreach {w => memPortMap(s"${m.name}.${w}.mask") = EmptyExpression}
+            m.readwriters foreach {w => memPortMap(s"${m.name}.${w}.wmask") = EmptyExpression}
+          }
+          val infoT = getInfo(m.info,"info")
+          val info = if (infoT == None) NoInfo else infoT.get match {case i: Info => i}
+          val ref = getInfo(m.info,"ref")
+          
+          // prototype mem
+          if (ref == None) {
+            memMods ++= createMemModule(m)
+            uniqueMems += m
+            WDefInstance(info, m.name, m.name, UnknownType) 
+          }
+          else {
+            val r = ref.get match {case s: String => s}
+            WDefInstance(info, m.name, r, UnknownType) 
+          }
+        case b: Block => Block(b.stmts map updateMemStmts)
+        case s => s
+      }
+
+      val updatedMems = updateMemStmts(m.body)
+      val updatedConns = updateStmtRefs(updatedMems,memPortMap.toMap)
+      m.copy(body = updatedConns)
+    }
+
+    val updatedMods = c.modules map {
+      case m: Module => updateMemMods(m)
+      case m: ExtModule => m
+    }
+
+    memMods foreach { m => moduleNamespace.newName(m.name) }
+    c.copy(modules = updatedMods ++ memMods.toSeq) 
+  }  
+
+  // from Albert
+  def createMemModule(m: DefMemory): Seq[DefModule] = {
+    assert(m.dataType != UnknownType)
+    val bbName = m.name + "_ext"
+    val stmts = ArrayBuffer[Statement]()
+    val wrapperioPorts = MemPortUtils.memToBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
+    val bbProto = m.copy(dataType = UIntType(IntWidth(bitWidth(m.dataType))))
+    val bbioPorts = MemPortUtils.memToBundle(bbProto).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
+    stmts += WDefInstance(m.info,bbName,bbName,UnknownType)
+    val bbRef = createRef(bbName)
+    stmts ++= (m.readers zip bbProto.readers).map{ 
+      case (x,y) => adaptReader(createRef(x),m,createSubField(bbRef,y),bbProto)
+    }.flatten 
+    stmts ++= (m.writers zip bbProto.writers).map{ 
+      case (x,y) => adaptWriter(createRef(x),m,createSubField(bbRef,y),bbProto)
+    }.flatten 
+    stmts ++= (m.readwriters zip bbProto.readwriters).map{ 
+      case (x,y) => adaptReadWriter(createRef(x),m,createSubField(bbRef,y),bbProto)
+    }.flatten  
+    val wrapper = Module(m.info,m.name,wrapperioPorts,Block(stmts))   
+
+    println(wrapper.body.serialize)
+
+    val bb = ExtModule(m.info,bbName,bbioPorts) 
+    Seq(bb,wrapper)
+  }
+
+  def adaptReader(aggPort: Expression, aggMem: DefMemory, groundPort: Expression, groundMem: DefMemory) = Seq(
+    connectFields(groundPort,"addr",aggPort,"addr"),
+    connectFields(groundPort,"en",aggPort,"en"),
+    connectFields(groundPort,"clk",aggPort,"clk"),
+    fromBits(
+      WSubField(aggPort,"data",aggMem.dataType,UNKNOWNGENDER),
+      WSubField(groundPort,"data",groundMem.dataType,UNKNOWNGENDER)
+    )
+  )
+
+  def adaptWriter(aggPort: Expression, aggMem: DefMemory, groundPort: Expression, groundMem: DefMemory) = {
+    val defaultSeq = Seq(
+      connectFields(groundPort,"addr",aggPort,"addr"),
+      connectFields(groundPort,"en",aggPort,"en"),
+      connectFields(groundPort,"clk",aggPort,"clk"),
+      Connect(
+        NoInfo,
+        WSubField(groundPort,"data",groundMem.dataType,UNKNOWNGENDER),
+        toBits(WSubField(aggPort,"data",aggMem.dataType,UNKNOWNGENDER))
+      )
+    )
+    if (containsInfo(aggMem.info,"maskGran"))
+      defaultSeq :+ Connect(
+        NoInfo,
+        WSubField(groundPort,"mask",create_mask(groundMem.dataType),UNKNOWNGENDER),
+        toBitMask(WSubField(aggPort,"mask",create_mask(aggMem.dataType),UNKNOWNGENDER),aggMem.dataType)
+      )
+    else defaultSeq
+  }
+
+  def adaptReadWriter(aggPort: Expression, aggMem: DefMemory, groundPort: Expression, groundMem: DefMemory) = {
+    val defaultSeq = Seq(
+      connectFields(groundPort,"addr",aggPort,"addr"),
+      connectFields(groundPort,"en",aggPort,"en"),
+      connectFields(groundPort,"clk",aggPort,"clk"),
+      connectFields(groundPort,"wmode",aggPort,"wmode"),
+      Connect(
+        NoInfo,
+        WSubField(groundPort,"wdata",groundMem.dataType,UNKNOWNGENDER),
+        toBits(WSubField(aggPort,"wdata",aggMem.dataType,UNKNOWNGENDER))
+      ),
+      fromBits(
+        WSubField(aggPort,"rdata",aggMem.dataType,UNKNOWNGENDER),
+        WSubField(groundPort,"rdata",groundMem.dataType,UNKNOWNGENDER)
+      )
+    )
+    if (containsInfo(aggMem.info,"maskGran"))
+      defaultSeq :+ Connect(
+        NoInfo,
+        WSubField(groundPort,"wmask",create_mask(groundMem.dataType),UNKNOWNGENDER),
+        toBitMask(WSubField(aggPort,"wmask",create_mask(aggMem.dataType),UNKNOWNGENDER),aggMem.dataType)
+      )
+    else defaultSeq
+  }
+
+}

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -33,9 +33,11 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
           
           // prototype mem
           if (ref == None) {
-            memMods ++= createMemModule(m)
-            uniqueMems += m
-            WDefInstance(info, m.name, m.name, UnknownType) 
+            val newName = moduleNamespace.newName(m.name)
+            val newMem = m.copy(name = newName)
+            memMods ++= createMemModule(newMem)
+            uniqueMems += newMem
+            WDefInstance(info, m.name, newMem.name, UnknownType) 
           }
           else {
             val r = ref.get match {case s: String => s}
@@ -55,7 +57,6 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
       case m: ExtModule => m
     }
 
-    memMods foreach { m => moduleNamespace.newName(m.name) }
     // print conf
     writer.serialize
     c.copy(modules = updatedMods ++ memMods.toSeq) 

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -71,7 +71,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
     //val bbioPorts = MemPortUtils.memToBundle(bbProto).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
     val bbioPorts = MemPortUtils.memToFlattenBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
 
-    stmts += WDefInstance(m.info,bbName,bbName,UnknownType)
+    stmts += WDefInstance(NoInfo,bbName,bbName,UnknownType)
     val bbRef = createRef(bbName)
     stmts ++= (m.readers zip bbProto.readers).map{ 
       case (x,y) => adaptReader(createRef(x),m,createSubField(bbRef,y),bbProto)
@@ -82,11 +82,9 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
     stmts ++= (m.readwriters zip bbProto.readwriters).map{ 
       case (x,y) => adaptReadWriter(createRef(x),m,createSubField(bbRef,y),bbProto)
     }.flatten  
-    val wrapper = Module(m.info,m.name,wrapperioPorts,Block(stmts))   
-
-    //println(wrapper.body.serialize)
-
-    val bb = ExtModule(m.info,bbName,bbioPorts) 
+    val wrapper = Module(NoInfo,m.name,wrapperioPorts,Block(stmts))   
+    val bb = ExtModule(NoInfo,bbName,bbioPorts) 
+    // TODO: Annotate? -- use actual annotation map
 
     // add to conf file
     writer.append(m)

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -8,9 +8,9 @@ import firrtl._
 import firrtl.Utils._
 import MemPortUtils._
 
-object ReplaceMemMacros extends Pass {
+class ReplaceMemMacros(writer: ConfWriter) extends Pass {
 
-  def name = "Replace memories with black box wrappers (optimizes when write mask isn't needed)"
+  def name = "Replace memories with black box wrappers (optimizes when write mask isn't needed) + configuration file"
 
   def run(c: Circuit) = {
 
@@ -56,6 +56,8 @@ object ReplaceMemMacros extends Pass {
     }
 
     memMods foreach { m => moduleNamespace.newName(m.name) }
+    // print conf
+    writer.serialize
     c.copy(modules = updatedMods ++ memMods.toSeq) 
   }  
 
@@ -85,6 +87,9 @@ object ReplaceMemMacros extends Pass {
     //println(wrapper.body.serialize)
 
     val bb = ExtModule(m.info,bbName,bbioPorts) 
+
+    // add to conf file
+    writer.append(m)
     Seq(bb,wrapper)
   }
 

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -7,6 +7,7 @@ import MemTransformUtils._
 import firrtl._
 import firrtl.Utils._
 import MemPortUtils._
+import firrtl.Mappers._
 
 class ReplaceMemMacros(writer: ConfWriter) extends Pass {
 
@@ -44,7 +45,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
             val r = ref.get match {case s: String => s}
             WDefInstance(info, m.name, r, UnknownType) 
           }
-        case b: Block => Block(b.stmts map updateMemStmts)
+        case b: Block => b map updateMemStmts
         case s => s
       }
 

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -6,6 +6,7 @@ import AnalysisUtils._
 import MemTransformUtils._
 import firrtl._
 import firrtl.Utils._
+import MemPortUtils._
 
 object ReplaceMemMacros extends Pass {
 
@@ -64,8 +65,10 @@ object ReplaceMemMacros extends Pass {
     val bbName = m.name + "_ext"
     val stmts = ArrayBuffer[Statement]()
     val wrapperioPorts = MemPortUtils.memToBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
-    val bbProto = m.copy(dataType = UIntType(IntWidth(bitWidth(m.dataType))))
-    val bbioPorts = MemPortUtils.memToBundle(bbProto).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
+    val bbProto = m.copy(dataType = flattenType(m.dataType))
+    //val bbioPorts = MemPortUtils.memToBundle(bbProto).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
+    val bbioPorts = MemPortUtils.memToFlattenBundle(m).fields.map(f => Port(NoInfo, f.name, Input, f.tpe)) 
+
     stmts += WDefInstance(m.info,bbName,bbName,UnknownType)
     val bbRef = createRef(bbName)
     stmts ++= (m.readers zip bbProto.readers).map{ 
@@ -79,7 +82,7 @@ object ReplaceMemMacros extends Pass {
     }.flatten  
     val wrapper = Module(m.info,m.name,wrapperioPorts,Block(stmts))   
 
-    println(wrapper.body.serialize)
+    //println(wrapper.body.serialize)
 
     val bb = ExtModule(m.info,bbName,bbioPorts) 
     Seq(bb,wrapper)
@@ -106,12 +109,17 @@ object ReplaceMemMacros extends Pass {
         toBits(WSubField(aggPort,"data",aggMem.dataType,UNKNOWNGENDER))
       )
     )
-    if (containsInfo(aggMem.info,"maskGran"))
+    if (containsInfo(aggMem.info,"maskGran")) {
+      val wrapperMask = create_mask(aggMem.dataType)
+      val bbMask = flattenType(wrapperMask)
       defaultSeq :+ Connect(
         NoInfo,
-        WSubField(groundPort,"mask",create_mask(groundMem.dataType),UNKNOWNGENDER),
-        toBitMask(WSubField(aggPort,"mask",create_mask(aggMem.dataType),UNKNOWNGENDER),aggMem.dataType)
+        //WSubField(groundPort,"mask",create_mask(groundMem.dataType),UNKNOWNGENDER),
+        //toBitMask(WSubField(aggPort,"mask",create_mask(aggMem.dataType),UNKNOWNGENDER),aggMem.dataType)
+        WSubField(groundPort,"mask",bbMask,UNKNOWNGENDER),
+        toBits(WSubField(aggPort,"mask",wrapperMask,UNKNOWNGENDER))
       )
+    }
     else defaultSeq
   }
 
@@ -131,12 +139,17 @@ object ReplaceMemMacros extends Pass {
         WSubField(groundPort,"rdata",groundMem.dataType,UNKNOWNGENDER)
       )
     )
-    if (containsInfo(aggMem.info,"maskGran"))
+    if (containsInfo(aggMem.info,"maskGran")){
+      val wrapperMask = create_mask(aggMem.dataType)
+      val bbMask = flattenType(wrapperMask)
       defaultSeq :+ Connect(
         NoInfo,
-        WSubField(groundPort,"wmask",create_mask(groundMem.dataType),UNKNOWNGENDER),
-        toBitMask(WSubField(aggPort,"wmask",create_mask(aggMem.dataType),UNKNOWNGENDER),aggMem.dataType)
+        //WSubField(groundPort,"wmask",create_mask(groundMem.dataType),UNKNOWNGENDER),
+        //toBitMask(WSubField(aggPort,"wmask",create_mask(aggMem.dataType),UNKNOWNGENDER),aggMem.dataType)
+        WSubField(groundPort,"wmask",bbMask,UNKNOWNGENDER),
+        toBits(WSubField(aggPort,"wmask",wrapperMask,UNKNOWNGENDER))
       )
+    }
     else defaultSeq
   }
 

--- a/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
@@ -1,0 +1,94 @@
+package firrtl.passes
+
+import scala.collection.mutable.{HashMap,ArrayBuffer}
+import AnalysisUtils._
+import MemTransformUtils._
+import firrtl.ir._
+import firrtl._
+import firrtl.Mappers._
+import firrtl.Utils._
+
+object MemTransformUtils {
+
+  def createRef(n: String) = WRef(n,UnknownType,ExpKind(),UNKNOWNGENDER)
+  def createSubField(exp: Expression, n: String) = WSubField(exp,n,UnknownType,UNKNOWNGENDER)
+  def connectFields(lref: Expression, lname: String, rref: Expression, rname: String) = 
+    Connect(NoInfo,createSubField(lref,lname),createSubField(rref,rname))
+
+  def getMemPortMap(m: DefMemory) = {
+    val memPortMap = HashMap[String,Expression]()
+    val defaultFields = Seq("addr","en","clk")
+    val rFields = defaultFields :+ "data"
+    val wFields = rFields :+ "mask"
+    val rwFields = defaultFields ++ Seq("wmode","wdata","rdata","wmask")
+
+    def updateMemPortMap(ports: Seq[String], fields: Seq[String], portType: String) = 
+      for (p <- ports.zipWithIndex; f <- fields) {
+        val newPort = createSubField(createRef(m.name),portType+p._2)        
+        val field = createSubField(newPort,f)
+        memPortMap(s"${m.name}.${p._1}.${f}") = field
+      }
+    updateMemPortMap(m.readers,rFields,"R")
+    updateMemPortMap(m.writers,wFields,"W")
+    updateMemPortMap(m.readwriters,rwFields,"RW")
+    memPortMap.toMap
+  }
+  def createMemProto(m: DefMemory) = {
+    val rports = (0 until m.readers.length) map (i => s"R$i")
+    val wports = (0 until m.writers.length) map (i => s"W$i")
+    val rwports = (0 until m.readwriters.length) map (i => s"RW$i")
+    m.copy(readers = rports, writers = wports, readwriters = rwports)
+  }
+
+  def updateStmtRefs(s: Statement, repl: Map[String,Expression]): Statement = {
+    def updateRef(e: Expression): Expression = e map updateRef match {
+      case e: WSubField => repl getOrElse (e.serialize,e)
+      case e => e
+    }
+    def updateStmtRefs(s: Statement): Statement = s map updateStmtRefs map updateRef match {
+      case Connect(info, loc, exp) if loc == EmptyExpression => EmptyStmt 
+      case s => s
+    }
+    updateStmtRefs(s)
+  }
+
+}
+
+object UpdateDuplicateMemMacros extends Pass {
+
+  def name = "Convert memory port names to be more meaningful and tag duplicate memories"
+
+  def run(c: Circuit) = {
+    val uniqueMems = ArrayBuffer[DefMemory]()
+
+    def updateMemMods(m: Module) = {
+      val memPortMap = HashMap[String,Expression]()
+
+      def updateMemStmts(s: Statement): Statement = s match {
+        case m: DefMemory if containsInfo(m.info,"useMacro") => 
+          val updatedMem = createMemProto(m)
+          memPortMap ++= getMemPortMap(m)
+          val proto = uniqueMems find (x => eqMems(x,updatedMem))
+          if (proto == None) {
+            uniqueMems += updatedMem
+            updatedMem
+          } 
+          else updatedMem.copy(info = appendInfo(updatedMem.info,"ref" -> proto.get.name))
+        case b: Block => Block(b.stmts map updateMemStmts)
+        case s => s
+      }
+
+      val updatedMems = updateMemStmts(m.body)
+      val updatedConns = updateStmtRefs(updatedMems,memPortMap.toMap)
+      m.copy(body = updatedConns)
+    }
+
+    val updatedMods = c.modules map {
+      case m: Module => updateMemMods(m)
+      case m: ExtModule => m
+    }
+    c.copy(modules = updatedMods) 
+  }  
+
+}
+// TODO: Module namespace?

--- a/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
@@ -47,6 +47,7 @@ object MemTransformUtils {
     }
     def updateStmtRefs(s: Statement): Statement = s map updateStmtRefs map updateRef match {
       case Connect(info, loc, exp) if loc == EmptyExpression => EmptyStmt 
+      case Connect(info, WSubIndex(EmptyExpression,_,_,_), exp)  => EmptyStmt
       case s => s
     }
     updateStmtRefs(s)

--- a/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
@@ -75,7 +75,7 @@ object UpdateDuplicateMemMacros extends Pass {
             updatedMem
           } 
           else updatedMem.copy(info = appendInfo(updatedMem.info,"ref" -> proto.get.name))
-        case b: Block => Block(b.stmts map updateMemStmts)
+        case b: Block => b map updateMemStmts
         case s => s
       }
 

--- a/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
@@ -1,6 +1,8 @@
+// See LICENSE for license details.
+
 package firrtl.passes
 
-import scala.collection.mutable.{HashMap,ArrayBuffer}
+import scala.collection._
 import AnalysisUtils._
 import MemTransformUtils._
 import firrtl.ir._
@@ -10,27 +12,27 @@ import firrtl.Utils._
 
 object MemTransformUtils {
 
-  def createRef(n: String) = WRef(n,UnknownType,ExpKind(),UNKNOWNGENDER)
-  def createSubField(exp: Expression, n: String) = WSubField(exp,n,UnknownType,UNKNOWNGENDER)
+  def createRef(n: String) = WRef(n, UnknownType, ExpKind(), UNKNOWNGENDER)
+  def createSubField(exp: Expression, n: String) = WSubField(exp, n, UnknownType, UNKNOWNGENDER)
   def connectFields(lref: Expression, lname: String, rref: Expression, rname: String) = 
-    Connect(NoInfo,createSubField(lref,lname),createSubField(rref,rname))
+    Connect(NoInfo, createSubField(lref, lname), createSubField(rref, rname))
 
   def getMemPortMap(m: DefMemory) = {
-    val memPortMap = HashMap[String,Expression]()
-    val defaultFields = Seq("addr","en","clk")
+    val memPortMap = mutable.HashMap[String, Expression]()
+    val defaultFields = Seq("addr", "en", "clk")
     val rFields = defaultFields :+ "data"
     val wFields = rFields :+ "mask"
-    val rwFields = defaultFields ++ Seq("wmode","wdata","rdata","wmask")
+    val rwFields = defaultFields ++ Seq("wmode", "wdata", "rdata", "wmask")
 
     def updateMemPortMap(ports: Seq[String], fields: Seq[String], portType: String) = 
-      for (p <- ports.zipWithIndex; f <- fields) {
-        val newPort = createSubField(createRef(m.name),portType+p._2)        
-        val field = createSubField(newPort,f)
-        memPortMap(s"${m.name}.${p._1}.${f}") = field
+      for ((p, i) <- ports.zipWithIndex; f <- fields) {
+        val newPort = createSubField(createRef(m.name), portType+i)        
+        val field = createSubField(newPort, f)
+        memPortMap(s"${m.name}.${p}.${f}") = field
       }
-    updateMemPortMap(m.readers,rFields,"R")
-    updateMemPortMap(m.writers,wFields,"W")
-    updateMemPortMap(m.readwriters,rwFields,"RW")
+    updateMemPortMap(m.readers, rFields, "R")
+    updateMemPortMap(m.writers, wFields, "W")
+    updateMemPortMap(m.readwriters, rwFields, "RW")
     memPortMap.toMap
   }
   def createMemProto(m: DefMemory) = {
@@ -40,14 +42,14 @@ object MemTransformUtils {
     m.copy(readers = rports, writers = wports, readwriters = rwports)
   }
 
-  def updateStmtRefs(s: Statement, repl: Map[String,Expression]): Statement = {
+  def updateStmtRefs(s: Statement, repl: Map[String, Expression]): Statement = {
     def updateRef(e: Expression): Expression = e map updateRef match {
-      case e: WSubField => repl getOrElse (e.serialize,e)
+      case e: WSubField => repl getOrElse (e.serialize, e)
       case e => e
     }
     def updateStmtRefs(s: Statement): Statement = s map updateStmtRefs map updateRef match {
-      case Connect(info, loc, exp) if loc == EmptyExpression => EmptyStmt 
-      case Connect(info, WSubIndex(EmptyExpression,_,_,_), exp)  => EmptyStmt
+      case Connect(info, EmptyExpression, exp) => EmptyStmt 
+      case Connect(info, WSubIndex(EmptyExpression, _, _, _), exp)  => EmptyStmt
       case s => s
     }
     updateStmtRefs(s)
@@ -60,27 +62,27 @@ object UpdateDuplicateMemMacros extends Pass {
   def name = "Convert memory port names to be more meaningful and tag duplicate memories"
 
   def run(c: Circuit) = {
-    val uniqueMems = ArrayBuffer[DefMemory]()
+    val uniqueMems = mutable.ArrayBuffer[DefMemory]()
 
     def updateMemMods(m: Module) = {
-      val memPortMap = HashMap[String,Expression]()
+      val memPortMap = mutable.HashMap[String, Expression]()
 
       def updateMemStmts(s: Statement): Statement = s match {
-        case m: DefMemory if containsInfo(m.info,"useMacro") => 
+        case m: DefMemory if containsInfo(m.info, "useMacro") => 
           val updatedMem = createMemProto(m)
           memPortMap ++= getMemPortMap(m)
-          val proto = uniqueMems find (x => eqMems(x,updatedMem))
+          val proto = uniqueMems find (x => eqMems(x, updatedMem))
           if (proto == None) {
             uniqueMems += updatedMem
             updatedMem
           } 
-          else updatedMem.copy(info = appendInfo(updatedMem.info,"ref" -> proto.get.name))
+          else updatedMem.copy(info = appendInfo(updatedMem.info, "ref" -> proto.get.name))
         case b: Block => b map updateMemStmts
         case s => s
       }
 
       val updatedMems = updateMemStmts(m.body)
-      val updatedConns = updateStmtRefs(updatedMems,memPortMap.toMap)
+      val updatedConns = updateStmtRefs(updatedMems, memPortMap.toMap)
       m.copy(body = updatedConns)
     }
 

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -17,7 +17,7 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     new EmitFirrtl(writer)
   )
 
-  "ReplSeqMem" should "generated blackbox wrappers (no wmask, r, w ports)" in {
+  "ReplSeqMem" should "generate blackbox wrappers (no wmask, r, w ports)" in {
     val input = """
 circuit sram6t :
   module sram6t :

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -17,6 +17,51 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     new EmitFirrtl(writer)
   )
 
+  "ReplSeqMem Utility -- getConnectOrigin" should 
+      "determine connect origin across nodes/PrimOps even if ConstProp isn't performed" in {
+    def checkConnectOrigin(hurdle: String, origin: String) = {
+      val input = s"""
+circuit Top :
+  module Top :
+    input a: UInt<1>
+    input b: UInt<1>
+    input e: UInt<1>
+    output c: UInt<1>
+    output f: UInt<1>
+    node d = $hurdle
+    c <= d
+    f <= c
+""".stripMargin
+
+      val circuit = InferTypes.run(ToWorkingIR.run(parse(input)))
+      val m = circuit.modules.head.asInstanceOf[ir.Module]
+      val connects = AnalysisUtils.getConnects(m)
+      val calculatedOrigin = AnalysisUtils.getConnectOrigin(connects,"f").serialize 
+      require(calculatedOrigin == origin, s"getConnectOrigin returns incorrect origin $calculatedOrigin !")
+    }
+
+    val tests = List(
+      """mux(a, UInt<1>("h1"), UInt<1>("h0"))""" -> "a",
+      """mux(UInt<1>("h1"), a, b)""" -> "a",
+      """mux(UInt<1>("h0"), a, b)""" -> "b",
+      "mux(b, a, a)" -> "a",
+      """mux(a, a, UInt<1>("h0"))""" -> "a",
+      "mux(a, b, e)" -> "mux(a, b, e)",
+      """or(a, UInt<1>("h1"))""" -> """UInt<1>("h1")""",
+      """and(a, UInt<1>("h0"))""" -> """UInt<1>("h0")""",
+      """UInt<1>("h1")""" -> """UInt<1>("h1")""",
+      "asUInt(a)" -> "a",
+      "asSInt(a)" -> "a",
+      "asClock(a)" -> "a",
+      "a" -> "a",
+      "or(a, b)" -> "or(a, b)",
+      "bits(a, 0, 0)" -> "a"
+    )
+
+    tests.foreach{ case(hurdle, origin) => checkConnectOrigin(hurdle, origin) }
+
+  }
+
   "ReplSeqMem" should "generate blackbox wrappers (no wmask, r, w ports)" in {
     val input = """
 circuit sram6t :
@@ -116,7 +161,7 @@ circuit sram6t :
     val writer = new java.io.StringWriter
     execute(writer, aMap, input, check)
     val confOut = read(confLoc)
-    require(confOut==checkConf,"Conf file incorrect!")
+    require(confOut==checkConf, "Conf file incorrect!")
     (new java.io.File(confLoc)).delete()
   }
 }

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -107,7 +107,7 @@ circuit sram6t :
     mem_ext.W0_data <= W0_data     
 """.stripMargin
 
-    val checkConf = """name mem depth 128 width 32 ports write,read  """
+    val checkConf = """name mem_ext depth 128 width 32 ports write,read  """
     
     def read(file: String) = scala.io.Source.fromFile(file).getLines.mkString("\n")
     

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -1,0 +1,128 @@
+package firrtlTests
+
+import firrtl._
+import firrtl.passes._
+import Annotations._
+
+class ReplSeqMemSpec extends SimpleTransformSpec {
+
+  def transforms (writer: java.io.Writer) = Seq(
+    new Chisel3ToHighFirrtl(),
+    new IRToWorkingIR(),
+    new ResolveAndCheck(),
+    new HighFirrtlToMiddleFirrtl(),
+    new passes.InferReadWrite(TransID(-1)),
+    new passes.ReplSeqMem(TransID(-2)),
+    new MiddleFirrtlToLowFirrtl(),
+    new EmitFirrtl(writer)
+  )
+
+  "ReplSeqMem" should "generated blackbox wrappers (no wmask, r, w ports)" in {
+    val input = """
+circuit sram6t :
+  module sram6t :
+    input clk : Clock
+    input reset : UInt<1>
+    output io : {flip en : UInt<1>, flip wen : UInt<1>, flip waddr : UInt<8>, flip wdata : UInt<32>, flip raddr : UInt<8>, rdata : UInt<32>}
+
+    io is invalid
+    smem mem : UInt<32>[128]
+    node T_0 = eq(io.wen, UInt<1>("h00"))
+    node T_1 = and(io.en, T_0)
+    wire T_2 : UInt
+    T_2 is invalid
+    when T_1 :
+      T_2 <= io.raddr
+    read mport T_3 = mem[T_2], clk
+    io.rdata <= T_3
+    node T_4 = and(io.en, io.wen)
+    when T_4 :
+      write mport T_5 = mem[io.waddr], clk
+      T_5 <= io.wdata
+""".stripMargin
+
+    val check = """
+circuit sram6t :
+  module sram6t :
+    input clk : Clock
+    input reset : UInt<1>
+    input io_en : UInt<1>
+    input io_wen : UInt<1>
+    input io_waddr : UInt<8>
+    input io_wdata : UInt<32>
+    input io_raddr : UInt<8>
+    output io_rdata : UInt<32>
+  
+    inst mem of mem
+    node T_0 = eq(io_wen, UInt<1>("h0"))
+    node T_1 = and(io_en, T_0)
+    wire T_2 : UInt<8>
+    node GEN_0 = validif(T_1, io_raddr)
+    node GEN_1 = mux(T_1, UInt<1>("h1"), UInt<1>("h0"))
+    node T_4 = and(io_en, io_wen)
+    node GEN_2 = validif(T_4, io_waddr)
+    node GEN_3 = validif(T_4, clk)
+    node GEN_4 = mux(T_4, UInt<1>("h1"), UInt<1>("h0"))
+    node GEN_5 = validif(T_4, io_wdata)
+    node GEN_6 = mux(T_4, UInt<1>("h1"), UInt<1>("h0"))
+    io_rdata <= mem.R0_data
+    mem.R0_addr <= bits(T_2, 6, 0)
+    mem.R0_clk <= clk
+    mem.R0_en <= GEN_1
+    mem.W0_addr <= bits(GEN_2, 6, 0)
+    mem.W0_clk <= GEN_3
+    mem.W0_en <= GEN_4
+    mem.W0_data <= GEN_5
+    T_2 <= GEN_0
+
+  extmodule mem_ext :
+    input R0_addr : UInt<7>
+    input R0_en : UInt<1>
+    input R0_clk : Clock
+    output R0_data : UInt<32>
+    input W0_addr : UInt<7>
+    input W0_en : UInt<1>
+    input W0_clk : Clock
+    input W0_data : UInt<32>
+  
+
+  module mem :
+    input R0_addr : UInt<7>
+    input R0_en : UInt<1>
+    input R0_clk : Clock
+    output R0_data : UInt<32>
+    input W0_addr : UInt<7>
+    input W0_en : UInt<1>
+    input W0_clk : Clock
+    input W0_data : UInt<32>
+  
+    inst mem_ext of mem_ext
+    mem_ext.R0_addr <= R0_addr
+    mem_ext.R0_en <= R0_en
+    mem_ext.R0_clk <= R0_clk
+    R0_data <= bits(mem_ext.R0_data, 31, 0)
+    mem_ext.W0_addr <= W0_addr
+    mem_ext.W0_en <= W0_en
+    mem_ext.W0_clk <= W0_clk
+    mem_ext.W0_data <= W0_data     
+""".stripMargin
+
+    val checkConf = """name mem depth 128 width 32 ports write,read  """
+    
+    def read(file: String) = scala.io.Source.fromFile(file).getLines.mkString("\n")
+    
+    val confLoc = "ReplSeqMemTests.confTEMP"
+    val aMap = AnnotationMap(Seq(ReplSeqMemAnnotation("-c:sram6t:-o:"+confLoc, TransID(-2))))
+    val writer = new java.io.StringWriter
+    execute(writer, aMap, input, check)
+    val confOut = read(confLoc)
+    require(confOut==checkConf,"Conf file incorrect!")
+    (new java.io.File(confLoc)).delete()
+  }
+}
+
+// TODO: make more checks
+// readwrite vs. no readwrite
+// redundant memories (multiple instances of the same type of memory)
+// mask + no mask
+// conf


### PR DESCRIPTION
Initial ReplSeqMem transform. Would appreciate code review :) @azidar @jackkoenig 

Needs to be run with the following arguments: --replSeqMem -c:circuit:-i:inputConf:-o:outputConf
inputConf isn't actually used right now. It's just a placeholder. 
Default rocket "make run-asm-tests" seems to pass (still in the middle of running through tests). 

Some notes:
* I just commented out some code that might be useful later (i.e. filling the mask bits to the full datawidth) to be consistent w/ the newest vlsi_mem_gen template. 
* The transform has "sub arguments" delimited by ":" b/c I wanted to be able to pass in conf file locations.
* The transform consists of 3 separate passes (sort of separation of concern-y???).

 -  Annotate sequential memories that are candidates for macro replacement + determine if write mask is needed. The need for write mask is determined by checking to see if wmode/en and wmask have the same origin in a module. 
 - Look for unique mem modules that need to be created (memories tagged with "prototype" references) and change references to use more meaningful port names (i.e. RW0 instead T_408)
 - Replace DefMemory with memory blackbox + wrapper + conf file. This will not generate wmask ports if not needed. Creates the minimum # of black boxes needed by the design. 

Throughout the 3 passes, I "annotate" information like maskGran, etc. via modding the DefMemory "Info". I know that isn't the intention of "Info", but it was easier to inline the annotations that way, at least for the time being. When the Annotation system becomes more mature, I'd like to, at the very least, tag the generated Module/ExtModule's with more information. 

Future:
* Add more unit tests (rw vs. r,w; mask vs. no mask; properly takes care of redundant memories)
* Split memory based off of input conf information
* Eventually get rid of the need for vlsi_mem_gen

I know I'm not conforming to Scala coding best practices. Was thinking of running this through some auto formatter later. 