### PR TITLE
Finer grained control over randomization

### DIFF
--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -106,6 +106,16 @@ circuit Top :
     b <= a
 """
    val check = Seq(
+      "`ifdef RANDOMIZE_ASSIGN",
+      "`define RANDOMIZE",
+      "`endif",
+      "`ifdef RANDOMIZE_REG_INIT",
+      "`define RANDOMIZE",
+      "`endif",
+      "`ifdef RANDOMIZE_MEM_INIT",
+      "`define RANDOMIZE",
+      "`endif",
+      "",
       "module Top(",
       "  input   a_0,",
       "  input   a_1,",


### PR DESCRIPTION
We previously had `ifdef guards on some parts of the emitted verilog to
control whether some registers or nets should be given random initial
values. These guards were all dependent on the RANDOMIZE macro.

However, there were actually three separate cases being controlled

 1. Giving random values to disconnected wires
 2. Random initialization of registers
 3. Random initialization of memories

It is possible that the designer would want to switch these three on or
off independently in simulation. For instance, the latter two are
usually safe because registers and memories will get some definite
binary value at power on in the actual circuit, but the first one can
be quite dangerous because the undriven wire could be metastable.

This change provides separate macros for each of the three sets of
guards so that they can be controlled independently.