### PR TITLE
Emit wires instead of registers for invalid randomization

### DIFF
--- a/src/test/scala/firrtlTests/CompilerTests.scala
+++ b/src/test/scala/firrtlTests/CompilerTests.scala
@@ -106,7 +106,10 @@ circuit Top :
     b <= a
 """
    val check = Seq(
-      "`ifdef RANDOMIZE_ASSIGN",
+      "`ifdef RANDOMIZE_GARBAGE_ASSIGN",
+      "`define RANDOMIZE",
+      "`endif",
+      "`ifdef RANDOMIZE_INVALID_ASSIGN",
       "`define RANDOMIZE",
       "`endif",
       "`ifdef RANDOMIZE_REG_INIT",


### PR DESCRIPTION
This fixes an issue with my previous PR that I overlooked.

Before, the verilog emitter would connect registers to the invalid ports
and use random initialization on the generated registers.

This makes it impossible to separately configure randomization of the invalid ports from randomization of the initial register contents.

It also means there may be a bunch of useless registers in the taped out design. Not sure how well the synthesis tools optimize out registers that never get initialized.

It is better to just generate wires instead and use random assignment on the
wires. This makes it possible to simply leave the invalid ports floating. If they were actually being used to drive other nets, you would see an issue in simulation. If not, the synthesis tools should optimize them out.