### PR TITLE
Change null statement to empty begin end

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -657,7 +657,7 @@ class VerilogEmitter extends Emitter {
             //  then start the simulation later
             // Verilator does not support delay statements, so they are omitted.
             emit(Seq("    `ifndef verilator"))
-            emit(Seq("      #0.002;"))
+            emit(Seq("      #0.002 begin end"))
             emit(Seq("    `endif"))
             for (x <- initials) {
                emit(Seq(tab,x))


### PR DESCRIPTION
this eliminates warnings in recent versions of VCS

Fixes #262 