### PR TITLE
Bug fix -- remove all empty expressions after ReplSeqMem passes

### DIFF
--- a/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
@@ -43,13 +43,23 @@ object MemTransformUtils {
   }
 
   def updateStmtRefs(s: Statement, repl: Map[String, Expression]): Statement = {
-    def updateRef(e: Expression): Expression = e map updateRef match {
-      case e: WSubField => repl getOrElse (e.serialize, e)
-      case e => e
+    def updateRef(e: Expression): Expression = e map updateRef match { 
+      case e => repl getOrElse (e.serialize, e) 
+    }
+    def hasEmptyExpr(stmt: Statement): Boolean = {
+      var foundEmpty = false
+      def testEmptyExpr(e: Expression): Expression = {
+        e map testEmptyExpr match {
+          case EmptyExpression => foundEmpty = true
+          case _ =>
+        }
+        e // map must return; no foreach
+      }
+      stmt map testEmptyExpr
+      foundEmpty
     }
     def updateStmtRefs(s: Statement): Statement = s map updateStmtRefs map updateRef match {
-      case Connect(info, EmptyExpression, exp) => EmptyStmt 
-      case Connect(info, WSubIndex(EmptyExpression, _, _, _), exp)  => EmptyStmt
+      case c: Connect if hasEmptyExpr(c) => EmptyStmt
       case s => s
     }
     updateStmtRefs(s)

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -16,9 +16,54 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     new passes.ReplSeqMem(TransID(-2)),
     new MiddleFirrtlToLowFirrtl(),
     (new Transform with SimpleRun {
-     def execute(c: ir.Circuit, a: AnnotationMap) = run(c, passSeq) }),
+     def execute(c: ir.Circuit, a: AnnotationMap) = run(c, passSeq) } ),
     new EmitFirrtl(writer)
   )
+
+  "ReplSeqMem" should "generate blackbox wrappers" in {
+    val input = """
+circuit Top : 
+  module Top : 
+    input clk : Clock
+    input reset : UInt<1>
+    input head_ptr : UInt<5>
+    input tail_ptr : UInt<5>
+    input wmask : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}
+    output io : {backend : {flip allocate : {valid : UInt<1>, bits : {info : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}}}}, commit_entry : {valid : UInt<1>, bits : {info : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}}}}
+    output io2 : {backend : {flip allocate : {valid : UInt<1>, bits : {info : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}}}}, commit_entry : {valid : UInt<1>, bits : {info : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}}}}
+
+    io is invalid
+    io2 is invalid
+
+    smem entries_info : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}[24]
+    when io.backend.allocate.valid :
+      write mport W = entries_info[tail_ptr], clk
+      W <- io.backend.allocate.bits.info
+
+    read mport R = entries_info[head_ptr], clk
+    io.commit_entry.bits.info <- R
+
+    smem entries_info2 : {takens : UInt<2>, history : UInt<14>, info : UInt<14>}[24]
+    when io2.backend.allocate.valid :
+      write mport W1 = entries_info2[tail_ptr], clk
+      when wmask.takens :
+        W1.takens <- io.backend.allocate.bits.info.takens
+      when wmask.history :
+        W1.history <- io.backend.allocate.bits.info.history
+      when wmask.info :
+        W1.info <- io.backend.allocate.bits.info.history
+      
+    read mport R1 = entries_info2[head_ptr], clk
+    io2.commit_entry.bits.info <- R1
+""".stripMargin
+    val confLoc = "ReplSeqMemTests.confTEMP"
+    val aMap = AnnotationMap(Seq(ReplSeqMemAnnotation("-c:Top:-o:"+confLoc, TransID(-2))))
+    val writer = new java.io.StringWriter
+    compile(parse(input), aMap, writer)
+    // Check correctness of firrtl
+    parse(writer.toString)
+    (new java.io.File(confLoc)).delete()
+  }
 
   "ReplSeqMem Utility -- getConnectOrigin" should 
       "determine connect origin across nodes/PrimOps even if ConstProp isn't performed" in {
@@ -61,7 +106,7 @@ circuit Top :
       "bits(a, 0, 0)" -> "a"
     )
 
-    tests.foreach{ case(hurdle, origin) => checkConnectOrigin(hurdle, origin) }
+    tests foreach { case(hurdle, origin) => checkConnectOrigin(hurdle, origin) }
 
   }
 }


### PR DESCRIPTION
Addresses #292 
@ccelio can you try this and see if it works  (compiles + simulates)?
@jackkoenig @azidar -- do you think it's better to do something like this or just case out WSubField, WSubIndex, and EmptyExpression (assuming those are the only 3 possible?) 

