### PR TITLE
Fix bits type redo

### DIFF
--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -124,7 +124,6 @@ class HighFirrtlToMiddleFirrtl () extends Transform with SimpleRun {
 // TODO(izraelevitz): Create RenameMap from RemoveCHIRRTL
 class MiddleFirrtlToLowFirrtl () extends Transform with SimpleRun {
    val passSeq = Seq(
-      passes.Legalize,
       passes.LowerTypes,
       passes.ResolveKinds,
       passes.InferTypes,
@@ -146,6 +145,7 @@ class EmitVerilogFromLowFirrtl (val writer: Writer) extends Transform with Simpl
       passes.ConstProp,
       passes.PadWidths,
       passes.ConstProp,
+      passes.Legalize,
       passes.VerilogWrap,
       passes.SplitExpressions,
       passes.CommonSubexpressionElimination,

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -329,6 +329,9 @@ abstract class GroundType extends Type {
   val width: Width
   def mapType(f: Type => Type): Type = this
 }
+object GroundType {
+  def unapply(ground: GroundType): Option[Width] = Some(ground.width)
+}
 abstract class AggregateType extends Type {
   def mapWidth(f: Width => Width): Type = this
 }

--- a/src/main/scala/firrtl/passes/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/MemUtils.scala
@@ -83,8 +83,7 @@ object bitWidth {
   def widthOf(dt: Type): BigInt = dt match {
     case t: VectorType => t.size * bitWidth(t.tpe)
     case t: BundleType => t.fields.map(f => bitWidth(f.tpe)).foldLeft(BigInt(0))(_+_)
-    case UIntType(IntWidth(width)) => width
-    case SIntType(IntWidth(width)) => width
+    case GroundType(IntWidth(width)) => width
     case t => error("Unknown type encountered in bitWidth!")
   }
 }

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -18,11 +18,18 @@ object PadWidths extends Pass {
          case t: SIntType => SIntType(IntWidth(i))
          // default case should never be reached
       }
-      if (i > width(e))
+      if (i > width(e)) {
          DoPrim(Pad, Seq(e), Seq(i), tx)
-      else if (i < width(e))
-         DoPrim(Bits, Seq(e), Seq(i - 1, 0), tx)
-      else e
+      } else if (i < width(e)) {
+         val e2 = DoPrim(Bits, Seq(e), Seq(i - 1, 0), UIntType(IntWidth(i)))
+         // Bit Select always returns UInt, cast if selecting from SInt
+         e.tpe match {
+            case UIntType(_) => e2
+            case SIntType(_) => DoPrim(AsSInt, Seq(e2), Seq.empty, SIntType(IntWidth(i)))
+         }
+      } else {
+        e
+      }
    }
    // Recursive, updates expression so children exp's have correct widths
    private def onExp(e: Expression): Expression = {

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -238,6 +238,13 @@ object Legalize extends Pass {
       case _ => expr
     }
   }
+  private def legalizePad(expr: DoPrim): Expression = expr.args.head match {
+    case UIntLiteral(value, IntWidth(width)) if (width < expr.consts.head) =>
+      UIntLiteral(value, IntWidth(expr.consts.head))
+    case SIntLiteral(value, IntWidth(width)) if (width < expr.consts.head) =>
+      SIntLiteral(value, IntWidth(expr.consts.head))
+    case _ => expr
+  }
   private def legalizeConnect(c: Connect): Statement = {
     val t = c.loc.tpe
     val w = bitWidth(t)
@@ -256,6 +263,7 @@ object Legalize extends Pass {
     def legalizeE(expr: Expression): Expression = expr map legalizeE match {
       case prim: DoPrim => prim.op match {
         case Shr => legalizeShiftRight(prim)
+        case Pad => legalizePad(prim)
         case Bits => legalizeBits(prim)
         case _ => prim
       }

--- a/src/test/resources/passes/Legalize/Legalize.fir
+++ b/src/test/resources/passes/Legalize/Legalize.fir
@@ -1,0 +1,41 @@
+
+circuit Legalize :
+  module Legalize :
+    input clk : Clock
+    input reset : UInt<1>
+
+    ; Count till done
+    node done = UInt(6)
+    reg count : UInt<16>, clk with :
+      reset => (reset, UInt(0))
+    when neq(count, done) :
+      count <= add(count, UInt(1))
+    when not(reset) :
+      when eq(count, done) :
+        stop(clk, UInt(1), 0)
+
+    ; Begin Test
+    ; Check assignment to smaller width
+    node x = UInt<32>("hdeadbeef")
+    wire y : UInt<16>
+    y <- x
+    when neq(y, UInt("hbeef")) :
+      printf(clk, UInt(1), "Assertion failed!\n y != beef\n")
+      stop(clk, UInt(1), 1)
+
+    ; Check bit select of literal
+    node b = bits(UInt("hd0"), 7, 5)
+    node b2 = bits(UInt("h9"), 3, 3)
+    when neq(b, UInt(6)) :
+      printf(clk, UInt(1), "Assertion failed!\n b != 6\n")
+      stop(clk, UInt(1), 1)
+    when neq(b2, UInt(1)) :
+      printf(clk, UInt(1), "Assertion failed!\n b2 != 1\n")
+      stop(clk, UInt(1), 1)
+
+    ; Check padding of literal
+    node bar = pad(SInt(-1), 16)
+    node bar_15 = bits(bar, 15, 15)
+    when neq(bar_15, UInt(1)) :
+      printf(clk, UInt(1), "Assertion failed!\n bar_15 != 0\n")
+      stop(clk, UInt(1), 1)

--- a/src/test/scala/firrtlTests/LegalizeSpec.scala
+++ b/src/test/scala/firrtlTests/LegalizeSpec.scala
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2014 - 2016 The Regents of the University of
+California (Regents). All Rights Reserved.  Redistribution and use in
+source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+   * Redistributions of source code must retain the above
+     copyright notice, this list of conditions and the following
+     two paragraphs of disclaimer.
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     two paragraphs of disclaimer in the documentation and/or other materials
+     provided with the distribution.
+   * Neither the name of the Regents nor the names of its contributors
+     may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+*/
+
+package firrtlTests
+
+import firrtl._
+
+class LegalizeSpec extends FirrtlFlatSpec {
+  behavior of "Legalize"
+
+  it should "compile and run" in {
+    runFirrtlTest("Legalize", "/passes/Legalize")
+  }
+}


### PR DESCRIPTION
Resurrected #174. Split out Debug Compilers for a separate PR.

This commit fixes a host of minor bugs and adds the appropriate tests to find them. These bug fixes are required in order for the compiler to be rerun after lowering (eg. for transformations that want to operate on low FIRRTL then rerun the compiler).

I wasn't sure before, and I'm definitely not sure now whether or not the constant propogation of pad widths I added to Legalize should be there. This is a linting warning so it's not clear that it is a required "legalization" but the warning it was exercising used to be an error in Verilator so it's probably a good idea to not exercise it. I'm also not sure if it got fixed elsewhere somehow over the last few months but I wouldn't be surprised.

