### PR TITLE
Fix a lurking width-inference bug; improve adjacent style

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -81,23 +81,14 @@ object Utils extends LazyLogging {
     else "\"h" + bi.toString(16) + "\""
 
   implicit def toWrappedExpression (x:Expression) = new WrappedExpression(x)
-  def ceil_log2(x: BigInt): BigInt = (x-1).bitLength
-  def ceil_log2(x: Int): Int = scala.math.ceil(scala.math.log(x) / scala.math.log(2)).toInt
+  def ceilLog2(x: BigInt): Int = (x-1).bitLength
   def max(a: BigInt, b: BigInt): BigInt = if (a >= b) a else b
   def min(a: BigInt, b: BigInt): BigInt = if (a >= b) b else a
   def pow_minus_one(a: BigInt, b: BigInt): BigInt = a.pow(b.toInt) - 1
   val BoolType = UIntType(IntWidth(1))
   val one  = UIntLiteral(BigInt(1), IntWidth(1))
   val zero = UIntLiteral(BigInt(0), IntWidth(1))
-  def uint(i: Int): UIntLiteral = {
-    val num_bits = req_num_bits(i)
-    val w = IntWidth(scala.math.max(1, num_bits - 1))
-    UIntLiteral(BigInt(i), w)
-  }
-  def req_num_bits(i: Int): Int = {
-    val ix = if (i < 0) ((-1 * i) - 1) else i
-    ceil_log2(ix + 1) + 1
-  }
+  def uint(i: BigInt): UIntLiteral = UIntLiteral(i, IntWidth(1 max i.bitLength))
 
   def create_exps(n: String, t: Type): Seq[Expression] =
     create_exps(WRef(n, t, ExpKind, UNKNOWNGENDER))

--- a/src/main/scala/firrtl/passes/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/MemUtils.scala
@@ -152,7 +152,7 @@ object MemPortUtils {
   def flattenType(t: Type) = UIntType(IntWidth(bitWidth(t)))
 
   def defaultPortSeq(mem: DefMemory) = Seq(
-    Field("addr", Default, UIntType(IntWidth(ceil_log2(mem.depth) max 1))),
+    Field("addr", Default, UIntType(IntWidth(ceilLog2(mem.depth) max 1))),
     Field("en", Default, BoolType),
     Field("clk", Default, ClockType)
   )

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -88,7 +88,7 @@ object RemoveCHIRRTL extends Pass {
       refs: DataRefMap, raddrs: AddrMap)(s: Statement): Statement = s match {
     case (s: CDefMemory) =>
       types(s.name) = s.tpe
-      val taddr = UIntType(IntWidth(math.max(1, ceil_log2(s.size))))
+      val taddr = UIntType(IntWidth(1 max ceilLog2(s.size)))
       val tdata = s.tpe
       def set_poison(vec: Seq[MPort], addr: String) = vec flatMap (r => Seq(
         IsInvalid(s.info, SubField(SubField(Reference(s.name, ut), r.name, ut), addr, taddr)),


### PR DESCRIPTION
ceil(log(x) / log(2)) does not, in general, round to ceil(log2(x)).
I noticed this because of #297.