### PR TITLE
Fixed OF for finding connect origin in ReplSeqMem

### DIFF
--- a/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
@@ -45,7 +45,12 @@ object AnalysisUtils {
   // limitation: only works in a module (stops @ module inputs)
   // TODO: more thorough (i.e. a + 0 = a)
   def getConnectOrigin(connects: Map[String, Expression], node: String): Expression = {
-    if (connects contains node) getOrigin(connects, connects(node))
+    if (connects contains node) {
+      val exp = connects(node)
+      // handles case when a node is connected to itself (connecting reg output back to input)
+      if (exp.serialize == node) exp
+      else getOrigin(connects, exp)
+    }
     else EmptyExpression
   }
 

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -20,7 +20,7 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     new EmitFirrtl(writer)
   )
 
-  "ReplSeqMem" should "generate blackbox wrappers" in {
+  "ReplSeqMem" should "generate blackbox wrappers for mems of bundle type" in {
     val input = """
 circuit Top : 
   module Top : 
@@ -55,6 +55,29 @@ circuit Top :
       
     read mport R1 = entries_info2[head_ptr], clk
     io2.commit_entry.bits.info <- R1
+""".stripMargin
+    val confLoc = "ReplSeqMemTests.confTEMP"
+    val aMap = AnnotationMap(Seq(ReplSeqMemAnnotation("-c:Top:-o:"+confLoc, TransID(-2))))
+    val writer = new java.io.StringWriter
+    compile(parse(input), aMap, writer)
+    // Check correctness of firrtl
+    parse(writer.toString)
+    (new java.io.File(confLoc)).delete()
+  }
+
+  "ReplSeqMem" should "not infinite loop if control signals are derived from registered versions of themselves" in {
+    val input = """
+circuit Top :
+  module Top :
+    input clk : Clock
+    input hsel : UInt<1>
+
+    reg p_valid : UInt<1>, clk
+    reg p_address : UInt<5>, clk
+    smem mem : UInt<8>[8][32] 
+    when hsel : 
+      when p_valid : 
+        write mport T_155 = mem[p_address], clk
 """.stripMargin
     val confLoc = "ReplSeqMemTests.confTEMP"
     val aMap = AnnotationMap(Seq(ReplSeqMemAnnotation("-c:Top:-o:"+confLoc, TransID(-2))))


### PR DESCRIPTION
* Addressed the fact that a node can be connected to itself (updating reg) [Issue #299]