### PR TITLE
Fix non-determinism bug in ExpandWhens

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -114,9 +114,9 @@ object ExpandWhens extends Pass {
           val conseqStmt = expandWhens(conseqNetlist, netlist +: defaults, AND(p, s.pred))(s.conseq)
           val altStmt = expandWhens(altNetlist, netlist +: defaults, AND(p, NOT(s.pred)))(s.alt)
 
-          // Process combined set of keys because we only want to create 1 mux for each node
-          //   being connected to in the conseq and/or alt
-          val memos = (conseqNetlist.keySet ++ altNetlist.keySet) map { lvalue =>
+          // Process combined maps because we only want to create 1 mux for each node
+          //   present in the conseq and/or alt
+          val memos = (conseqNetlist ++ altNetlist) map { case (lvalue, _) =>
             // Defaults in netlist get priority over those in defaults
             val default = netlist get lvalue match {
               case Some(v) => Some(v)


### PR DESCRIPTION
Despite the fact that LinkedHashMaps preserve insertion order in traversal, it
appears that .keys and .keySet return Sets that do not provide the same
guarantee

Example test case below (surprisingly, reducing further seems to remove the non-determinism)

```
circuit Test :                                                                                                                                                                                                  
  module Test :
    input clk : Clock
    input reset : UInt<1>
    input io : {addr : UInt<32>, len : UInt<8>, size : UInt<3>, burst : UInt<2>, lock : UInt<1>}

    io is invalid
    reg ar : {addr : UInt<32>, len : UInt<8>, size : UInt<3>, burst : UInt<2>, lock : UInt<1>}, clk
    when reset : @[Reg.scala 29:19]
      ar <= io
```