### PR TITLE
fill empty module body with "begin end"

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -612,7 +612,7 @@ class VerilogEmitter extends Emitter {
         }
         emit(Seq(");"))
 
-        if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "begin end"))
+        if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "always @(*) begin end"))
         for (x <- declares) emit(Seq(tab, x))
         for (x <- instdeclares) emit(Seq(tab, x))
         for (x <- assigns) emit(Seq(tab, x))

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -612,6 +612,7 @@ class VerilogEmitter extends Emitter {
         }
         emit(Seq(");"))
 
+        if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "begin end"))
         for (x <- declares) emit(Seq(tab, x))
         for (x <- instdeclares) emit(Seq(tab, x))
         for (x <- assigns) emit(Seq(tab, x))


### PR DESCRIPTION
apparently vivado treats an empty module as a black box and triggers an error