### PR TITLE
Scala style cleanup take 5

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -88,7 +88,7 @@ class VerilogEmitter extends Emitter {
       case (t: UIntType) => e
       case (t: SIntType) => Seq("$signed(",e,")")
       case ClockType => e
-      case AnalogType(w) => e
+      case AnalogType(_) => e
     }
     x match {
       case (e: DoPrim) => emit(op_stream(e), top + 1)

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -242,21 +242,21 @@ class VerilogEmitter extends Emitter {
       val addrRegs = mutable.HashSet[WrappedExpression]()
       val namespace = Namespace(m)
       def build_netlist(s: Statement): Statement = s map build_netlist match {
-        case (s: Connect) =>
-          netlist(s.loc) = s.expr
-          (kind(s.loc), kind(s.expr)) match {
-            case (MemKind, RegKind) => addrRegs += s.expr
+        case sx: Connect =>
+          netlist(sx.loc) = sx.expr
+          (kind(sx.loc), kind(sx.expr)) match {
+            case (MemKind, RegKind) => addrRegs += sx.expr
             case _ =>
           }
-          s
-        case (s: IsInvalid) =>
-          netlist(s.expr) = wref(namespace.newTemp, s.expr.tpe)
-          s
-        case (s: DefNode) =>
-          val e = WRef(s.name, s.value.tpe, NodeKind, MALE)
-          netlist(e) = s.value
-          s
-        case (s) => s
+          sx
+        case sx: IsInvalid =>
+          netlist(sx.expr) = wref(namespace.newTemp, sx.expr.tpe)
+          sx
+        case sx: DefNode =>
+          val e = WRef(sx.name, sx.value.tpe, NodeKind, MALE)
+          netlist(e) = sx.value
+          sx
+        case sx => sx
       }
    
       val portdefs = ArrayBuffer[Seq[Any]]()
@@ -267,10 +267,10 @@ class VerilogEmitter extends Emitter {
       val initials = ArrayBuffer[Seq[Any]]()
       val simulates = ArrayBuffer[Seq[Any]]()
       def declare(b: String, n: String, t: Type) = t match {
-        case (t: VectorType) =>
-          declares += Seq(b, " ", t.tpe, " ", n, " [0:", t.size - 1, "];")
-        case (t) =>
-          declares += Seq(b, " ", t, " ", n,";")
+        case tx: VectorType =>
+          declares += Seq(b, " ", tx.tpe, " ", n, " [0:", tx.size - 1, "];")
+        case tx =>
+          declares += Seq(b, " ", tx, " ", n,";")
       }
       def assign(e: Expression, value: Expression) {
         assigns += Seq("assign ", e, " = ", value, ";")
@@ -417,58 +417,58 @@ class VerilogEmitter extends Emitter {
       }
 
       def build_streams(s: Statement): Statement = s map build_streams match {
-        case (s: DefWire) => 
-          declare("wire",s.name,s.tpe)
-          val e = wref(s.name,s.tpe)
+        case sx: DefWire =>
+          declare("wire",sx.name,sx.tpe)
+          val e = wref(sx.name,sx.tpe)
           netlist get e match {
             case Some(n) => assign(e,n)
             case None =>
           }
-          s
-        case (s: DefRegister) =>
-          declare("reg", s.name, s.tpe)
-          val e = wref(s.name, s.tpe)
-          update_and_reset(e, s.clock, s.reset, s.init)
+          sx
+        case sx: DefRegister =>
+          declare("reg", sx.name, sx.tpe)
+          val e = wref(sx.name, sx.tpe)
+          update_and_reset(e, sx.clock, sx.reset, sx.init)
           initialize(e)
-          s
-        case (s: IsInvalid) =>
-          val wref = netlist(s.expr) match { case e: WRef => e }
-          declare("reg", wref.name, s.expr.tpe)
+          sx
+        case sx: IsInvalid =>
+          val wref = netlist(sx.expr) match { case e: WRef => e }
+          declare("reg", wref.name, sx.expr.tpe)
           initialize(wref)
-          s
-        case (s: DefNode) =>
-          declare("wire", s.name, s.value.tpe)
-          assign(WRef(s.name, s.value.tpe, NodeKind, MALE), s.value)
-          s
-        case (s: Stop) =>
-          val errorString = StringLit(s"${s.ret}\n".getBytes)
-          simulate(s.clk, s.en, stop(s.ret), Some("STOP_COND"))
-          s
-        case (s: Print) =>
-          simulate(s.clk, s.en, printf(s.string, s.args), Some("PRINTF_COND"))
-          s
-        case (s: WDefInstanceConnector) =>
-          val es = create_exps(WRef(s.name, s.tpe, InstanceKind, MALE))
-          instdeclares += Seq(s.module, " ", s.name, " (")
-          (es zip s.exprs).zipWithIndex foreach {case ((l, r), i) =>
+          sx
+        case sx: DefNode =>
+          declare("wire", sx.name, sx.value.tpe)
+          assign(WRef(sx.name, sx.value.tpe, NodeKind, MALE), sx.value)
+          sx
+        case sx: Stop =>
+          val errorString = StringLit(s"${sx.ret}\n".getBytes)
+          simulate(sx.clk, sx.en, stop(sx.ret), Some("STOP_COND"))
+          sx
+        case sx: Print =>
+          simulate(sx.clk, sx.en, printf(sx.string, sx.args), Some("PRINTF_COND"))
+          sx
+        case sx: WDefInstanceConnector =>
+          val es = create_exps(WRef(sx.name, sx.tpe, InstanceKind, MALE))
+          instdeclares += Seq(sx.module, " ", sx.name, " (")
+          (es zip sx.exprs).zipWithIndex foreach {case ((l, r), i) =>
             val s = Seq(tab, ".", remove_root(l), "(", r, ")")
             if (i != es.size - 1) instdeclares += Seq(s, ",")
             else instdeclares += s
           }
           instdeclares += Seq(");")
-          s
-        case (s: DefMemory) =>
-          declare("reg", s.name, VectorType(s.dataType, s.depth))
-          initialize_mem(s)
-          if (s.readLatency != 0 || s.writeLatency != 1)
+          sx
+        case sx: DefMemory =>
+          declare("reg", sx.name, VectorType(sx.dataType, sx.depth))
+          initialize_mem(sx)
+          if (sx.readLatency != 0 || sx.writeLatency != 1)
             throw EmitterException("All memories should be transformed into " +
               "blackboxes or combinational by previous passses")
-          for (r <- s.readers) {
-            val data = memPortField(s, r, "data")
-            val addr = memPortField(s, r, "addr")
-            val en = memPortField(s, r, "en")
+          for (r <- sx.readers) {
+            val data = memPortField(sx, r, "data")
+            val addr = memPortField(sx, r, "addr")
+            val en = memPortField(sx, r, "en")
             // Ports should share an always@posedge, so can't have intermediary wire
-            val clk = netlist(memPortField(s, r, "clk"))
+            val clk = netlist(memPortField(sx, r, "clk"))
 
             declare("wire", LowerTypes.loweredName(data), data.tpe)
             declare("wire", LowerTypes.loweredName(addr), addr.tpe)
@@ -477,24 +477,24 @@ class VerilogEmitter extends Emitter {
             //; Read port
             assign(addr, netlist(addr)) //;Connects value to m.r.addr
             // assign(en, netlist(en))     //;Connects value to m.r.en
-            val mem = WRef(s.name, memType(s), MemKind, UNKNOWNGENDER)
-            val memPort = WSubAccess(mem, addr, s.dataType, UNKNOWNGENDER)
-            val depthValue = UIntLiteral(s.depth, IntWidth(BigInt(s.depth).bitLength))
+            val mem = WRef(sx.name, memType(sx), MemKind, UNKNOWNGENDER)
+            val memPort = WSubAccess(mem, addr, sx.dataType, UNKNOWNGENDER)
+            val depthValue = UIntLiteral(sx.depth, IntWidth(BigInt(sx.depth).bitLength))
             val garbageGuard = DoPrim(Geq, Seq(addr, depthValue), Seq(), UnknownType)
 
-            if ((s.depth & (s.depth - 1)) == 0)
+            if ((sx.depth & (sx.depth - 1)) == 0)
               assign(data, memPort)
             else
               garbageAssign(data, memPort, garbageGuard)
           }
  
-          for (w <- s.writers) {
-            val data = memPortField(s, w, "data")
-            val addr = memPortField(s, w, "addr")
-            val mask = memPortField(s, w, "mask")
-            val en = memPortField(s, w, "en")
+          for (w <- sx.writers) {
+            val data = memPortField(sx, w, "data")
+            val addr = memPortField(sx, w, "addr")
+            val mask = memPortField(sx, w, "mask")
+            val en = memPortField(sx, w, "en")
             //Ports should share an always@posedge, so can't have intermediary wire
-            val clk = netlist(memPortField(s, w, "clk"))
+            val clk = netlist(memPortField(sx, w, "clk"))
 
             declare("wire", LowerTypes.loweredName(data), data.tpe)
             declare("wire", LowerTypes.loweredName(addr), addr.tpe)
@@ -507,16 +507,16 @@ class VerilogEmitter extends Emitter {
             assign(mask, netlist(mask))
             assign(en, netlist(en))
 
-            val mem = WRef(s.name, memType(s), MemKind, UNKNOWNGENDER)
-            val memPort = WSubAccess(mem, addr, s.dataType, UNKNOWNGENDER)
+            val mem = WRef(sx.name, memType(sx), MemKind, UNKNOWNGENDER)
+            val memPort = WSubAccess(mem, addr, sx.dataType, UNKNOWNGENDER)
             update(memPort, data, clk, AND(en, mask))
           }
 
-          if (s.readwriters.nonEmpty)
+          if (sx.readwriters.nonEmpty)
             throw EmitterException("All readwrite ports should be transformed into " +
               "read & write ports by previous passes")
-          s
-        case s => s
+          sx
+        case sx => sx
       }
    
       def emit_streams() {

--- a/src/main/scala/firrtl/PrimOps.scala
+++ b/src/main/scala/firrtl/PrimOps.scala
@@ -102,7 +102,7 @@ object PrimOps extends LazyLogging {
   private lazy val builtinPrimOps: Seq[PrimOp] =
     Seq(Add, Sub, Mul, Div, Rem, Lt, Leq, Gt, Geq, Eq, Neq, Pad, AsUInt, AsSInt, AsClock, Shl, Shr,
         Dshl, Dshr, Neg, Cvt, Not, And, Or, Xor, Andr, Orr, Xorr, Cat, Bits, Head, Tail)
-  private lazy val strToPrimOp: Map[String, PrimOp] = builtinPrimOps map (op => op.toString -> op) toMap
+  private lazy val strToPrimOp: Map[String, PrimOp] = builtinPrimOps.map { case op : PrimOp=> op.toString -> op }.toMap
 
   /** Seq of String representations of [[ir.PrimOp]]s */
   lazy val listing: Seq[String] = builtinPrimOps map (_.toString)

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -72,7 +72,7 @@ object Utils extends LazyLogging {
         case 1 => newStmts.head
         case _ => Block(newStmts)
       }
-    case _ => s
+    case sx => sx
   }
 
   /** Indent the results of [[ir.FirrtlNode.serialize]] */

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -94,27 +94,27 @@ object Utils extends LazyLogging {
   def create_exps(n: String, t: Type): Seq[Expression] =
     create_exps(WRef(n, t, ExpKind, UNKNOWNGENDER))
   def create_exps(e: Expression): Seq[Expression] = e match {
-    case (e: Mux) =>
-      val e1s = create_exps(e.tval)
-      val e2s = create_exps(e.fval)
+    case ex: Mux =>
+      val e1s = create_exps(ex.tval)
+      val e2s = create_exps(ex.fval)
       e1s zip e2s map {case (e1, e2) =>
-        Mux(e.cond, e1, e2, mux_type_and_widths(e1, e2))
+        Mux(ex.cond, e1, e2, mux_type_and_widths(e1, e2))
       }
-    case (e: ValidIf) => create_exps(e.value) map (e1 => ValidIf(e.cond, e1, e1.tpe))
-    case (e) => e.tpe match {
-      case (_: GroundType) => Seq(e)
+    case ex: ValidIf => create_exps(ex.value) map (e1 => ValidIf(ex.cond, e1, e1.tpe))
+    case ex => ex.tpe match {
+      case (_: GroundType) => Seq(ex)
       case (t: BundleType) => (t.fields foldLeft Seq[Expression]())((exps, f) =>
-        exps ++ create_exps(WSubField(e, f.name, f.tpe,times(gender(e), f.flip))))
+        exps ++ create_exps(WSubField(ex, f.name, f.tpe,times(gender(ex), f.flip))))
       case (t: VectorType) => (0 until t.size foldLeft Seq[Expression]())((exps, i) =>
-        exps ++ create_exps(WSubIndex(e, i, t.tpe,gender(e))))
+        exps ++ create_exps(WSubIndex(ex, i, t.tpe,gender(ex))))
     }
   }
    def get_flip(t: Type, i: Int, f: Orientation): Orientation = {
      if (i >= get_size(t)) error("Shouldn't be here")
      t match {
        case (_: GroundType) => f
-       case (t: BundleType) => 
-         val (_, flip) = t.fields.foldLeft(i, None: Option[Orientation]) {
+       case (tx: BundleType) =>
+         val (_, flip) = tx.fields.foldLeft(i, None: Option[Orientation]) {
            case ((n, ret), x) if n < get_size(x.tpe) => ret match {
              case None => (n, Some(get_flip(x.tpe, n, times(x.flip, f))))
              case Some(_) => (n, ret)
@@ -122,13 +122,13 @@ object Utils extends LazyLogging {
            case ((n, ret), x) => (n - get_size(x.tpe), ret)
          }
          flip.get
-       case (t: VectorType) => 
-         val (_, flip) = (0 until t.size).foldLeft(i, None: Option[Orientation]) {
-           case ((n, ret), x) if n < get_size(t.tpe) => ret match {
-             case None => (n, Some(get_flip(t.tpe, n, f)))
+       case (tx: VectorType) =>
+         val (_, flip) = (0 until tx.size).foldLeft(i, None: Option[Orientation]) {
+           case ((n, ret), x) if n < get_size(tx.tpe) => ret match {
+             case None => (n, Some(get_flip(tx.tpe, n, f)))
              case Some(_) => (n, ret)
            }
-           case ((n, ret), x) => (n - get_size(t.tpe), ret)
+           case ((n, ret), x) => (n - get_size(tx.tpe), ret)
          }
          flip.get
      }
@@ -172,15 +172,15 @@ object Utils extends LazyLogging {
     mux_type_and_widths(e1.tpe, e2.tpe)
   def mux_type_and_widths(t1: Type, t2: Type): Type = {
     def wmax(w1: Width, w2: Width): Width = (w1, w2) match {
-      case (w1: IntWidth, w2: IntWidth) => IntWidth(w1.width max w2.width)
-      case (w1, w2) => MaxWidth(Seq(w1, w2))
+      case (w1x: IntWidth, w2x: IntWidth) => IntWidth(w1x.width max w2x.width)
+      case (w1x, w2x) => MaxWidth(Seq(w1x, w2x))
     }
     (t1, t2) match {
-      case (t1: UIntType, t2: UIntType) => UIntType(wmax(t1.width, t2.width))
-      case (t1: SIntType, t2: SIntType) => SIntType(wmax(t1.width, t2.width))
-      case (t1: VectorType, t2: VectorType) => VectorType(
-        mux_type_and_widths(t1.tpe, t2.tpe), t1.size)
-      case (t1: BundleType, t2: BundleType) => BundleType(t1.fields zip t2.fields map {
+      case (t1x: UIntType, t2x: UIntType) => UIntType(wmax(t1x.width, t2x.width))
+      case (t1x: SIntType, t2x: SIntType) => SIntType(wmax(t1x.width, t2x.width))
+      case (t1x: VectorType, t2x: VectorType) => VectorType(
+        mux_type_and_widths(t1x.tpe, t2x.tpe), t1x.size)
+      case (t1x: BundleType, t2x: BundleType) => BundleType(t1x.fields zip t2x.fields map {
         case (f1, f2) => Field(f1.name, f1.flip, mux_type_and_widths(f1.tpe, f2.tpe))
       })
       case _ => UnknownType
@@ -191,15 +191,15 @@ object Utils extends LazyLogging {
     case Port(_, name, dir, tpe) => Field(name, to_flip(dir), tpe)
   })
   def sub_type(v: Type): Type = v match {
-    case v: VectorType => v.tpe
-    case v => UnknownType
+    case vx: VectorType => vx.tpe
+    case vx => UnknownType
   }
   def field_type(v: Type, s: String) : Type = v match {
-    case v: BundleType => v.fields find (_.name == s) match {
+    case vx: BundleType => vx.fields find (_.name == s) match {
       case Some(f) => f.tpe
       case None => UnknownType
     }
-    case v => UnknownType
+    case vx => UnknownType
   }
    
 // =================================
@@ -207,23 +207,23 @@ object Utils extends LazyLogging {
 
 //// =============== EXPANSION FUNCTIONS ================
   def get_size(t: Type): Int = t match {
-    case (t: BundleType) => (t.fields foldLeft 0)(
+    case tx: BundleType => (tx.fields foldLeft 0)(
       (sum, f) => sum + get_size(f.tpe))
-    case (t: VectorType) => t.size * get_size(t.tpe)
-    case (t) => 1
+    case tx: VectorType => tx.size * get_size(tx.tpe)
+    case tx => 1
   }
 
   def get_valid_points(t1: Type, t2: Type, flip1: Orientation, flip2: Orientation): Seq[(Int,Int)] = {
     //;println_all(["Inside with t1:" t1 ",t2:" t2 ",f1:" flip1 ",f2:" flip2])
     (t1, t2) match {
-      case (t1: UIntType, t2: UIntType) => if (flip1 == flip2) Seq((0, 0)) else Nil
-      case (t1: SIntType, t2: SIntType) => if (flip1 == flip2) Seq((0, 0)) else Nil
-      case (t1: BundleType, t2: BundleType) =>
+      case (_: UIntType, _: UIntType) => if (flip1 == flip2) Seq((0, 0)) else Nil
+      case (_: SIntType, _: SIntType) => if (flip1 == flip2) Seq((0, 0)) else Nil
+      case (t1x: BundleType, t2x: BundleType) =>
         def emptyMap = Map[String, (Type, Orientation, Int)]()
-        val t1_fields = t1.fields.foldLeft(emptyMap, 0) { case ((map, ilen), f1) =>
+        val t1_fields = t1x.fields.foldLeft(emptyMap, 0) { case ((map, ilen), f1) =>
           (map + (f1.name ->(f1.tpe, f1.flip, ilen)), ilen + get_size(f1.tpe))
         }._1
-        t2.fields.foldLeft(Seq[(Int, Int)](), 0) { case ((points, jlen), f2) =>
+        t2x.fields.foldLeft(Seq[(Int, Int)](), 0) { case ((points, jlen), f2) =>
           t1_fields get f2.name match {
             case None => (points, jlen + get_size(f2.tpe))
             case Some((f1_tpe, f1_flip, ilen)) =>
@@ -233,12 +233,12 @@ object Utils extends LazyLogging {
               (points ++ (ls map { case (x, y) => (x + ilen, y + jlen) }), jlen + get_size(f2.tpe))
           }
         }._1
-      case (t1: VectorType, t2: VectorType) =>
-        val size = math.min(t1.size, t2.size)
+      case (t1x: VectorType, t2x: VectorType) =>
+        val size = math.min(t1x.size, t2x.size)
         (0 until size).foldLeft(Seq[(Int, Int)](), 0, 0) { case ((points, ilen, jlen), _) =>
-          val ls = get_valid_points(t1.tpe, t2.tpe, flip1, flip2)
-          (points ++ (ls map { case (x, y) => ((x + ilen), (y + jlen)) }),
-            ilen + get_size(t1.tpe), jlen + get_size(t2.tpe))
+          val ls = get_valid_points(t1x.tpe, t2x.tpe, flip1, flip2)
+          (points ++ (ls map { case (x, y) => (x + ilen, y + jlen) }),
+            ilen + get_size(t1x.tpe), jlen + get_size(t2x.tpe))
         }._1
       case (ClockType, ClockType) => if (flip1 == flip2) Seq((0, 0)) else Nil
       case (AnalogType(w1), AnalogType(w2)) => Nil
@@ -279,18 +279,18 @@ object Utils extends LazyLogging {
   }
 
   def field_flip(v: Type, s: String): Orientation = v match {
-    case (v: BundleType) => v.fields find (_.name == s) match {
+    case vx: BundleType => vx.fields find (_.name == s) match {
       case Some(ft) => ft.flip
       case None => Default
     }
-    case v => Default
+    case vx => Default
   }
   def get_field(v: Type, s: String): Field = v match {
-    case (v: BundleType) => v.fields find (_.name == s) match {
+    case vx: BundleType => vx.fields find (_.name == s) match {
       case Some(ft) => ft
       case None => error("Shouldn't be here")
     }
-    case v => error("Shouldn't be here")
+    case vx => error("Shouldn't be here")
   }
 
   def times(flip: Orientation, d: Direction): Direction = times(flip, d)
@@ -304,7 +304,7 @@ object Utils extends LazyLogging {
     case MALE => swap(d) // MALE == INPUT == REVERSE
   }
 
-  def times(g: Gender,flip: Orientation): Gender = times(flip, g)
+  def times(g: Gender, flip: Orientation): Gender = times(flip, g)
   def times(flip: Orientation, g: Gender): Gender = flip match {
     case Default => g
     case Flip => swap(g)
@@ -316,38 +316,38 @@ object Utils extends LazyLogging {
 
 // =========== ACCESSORS =========
   def kind(e: Expression): Kind = e match {
-    case e: WRef => e.kind
-    case e: WSubField => kind(e.exp)
-    case e: WSubIndex => kind(e.exp)
-    case e: WSubAccess => kind(e.exp)
-    case e => ExpKind
+    case ex: WRef => ex.kind
+    case ex: WSubField => kind(ex.exp)
+    case ex: WSubIndex => kind(ex.exp)
+    case ex: WSubAccess => kind(ex.exp)
+    case ex => ExpKind
   }
   def gender(e: Expression): Gender = e match {
-    case e: WRef => e.gender
-    case e: WSubField => e.gender
-    case e: WSubIndex => e.gender
-    case e: WSubAccess => e.gender
-    case e: DoPrim => MALE
-    case e: UIntLiteral => MALE
-    case e: SIntLiteral => MALE
-    case e: Mux => MALE
-    case e: ValidIf => MALE
+    case ex: WRef => ex.gender
+    case ex: WSubField => ex.gender
+    case ex: WSubIndex => ex.gender
+    case ex: WSubAccess => ex.gender
+    case ex: DoPrim => MALE
+    case ex: UIntLiteral => MALE
+    case ex: SIntLiteral => MALE
+    case ex: Mux => MALE
+    case ex: ValidIf => MALE
     case WInvalid => MALE
-    case e => println(e); error("Shouldn't be here")
+    case ex => println(ex); error("Shouldn't be here")
   }
   def get_gender(s: Statement): Gender = s match {
-    case s: DefWire => BIGENDER
-    case s: DefRegister => BIGENDER
-    case s: WDefInstance => MALE
-    case s: DefNode => MALE
-    case s: DefInstance => MALE
-    case s: DefMemory => MALE
-    case s: Block => UNKNOWNGENDER
-    case s: Connect => UNKNOWNGENDER
-    case s: PartialConnect => UNKNOWNGENDER
-    case s: Stop => UNKNOWNGENDER
-    case s: Print => UNKNOWNGENDER
-    case s: IsInvalid => UNKNOWNGENDER
+    case sx: DefWire => BIGENDER
+    case sx: DefRegister => BIGENDER
+    case sx: WDefInstance => MALE
+    case sx: DefNode => MALE
+    case sx: DefInstance => MALE
+    case sx: DefMemory => MALE
+    case sx: Block => UNKNOWNGENDER
+    case sx: Connect => UNKNOWNGENDER
+    case sx: PartialConnect => UNKNOWNGENDER
+    case sx: Stop => UNKNOWNGENDER
+    case sx: Print => UNKNOWNGENDER
+    case sx: IsInvalid => UNKNOWNGENDER
     case EmptyStmt => UNKNOWNGENDER
   }
   def get_gender(p: Port): Gender = if (p.direction == Input) MALE else FEMALE

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -72,7 +72,7 @@ object Utils extends LazyLogging {
         case 1 => newStmts.head
         case _ => Block(newStmts)
       }
-    case s => s
+    case _ => s
   }
 
   /** Indent the results of [[ir.FirrtlNode.serialize]] */

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -128,20 +128,20 @@ object WrappedExpression {
 class WrappedExpression(val e1: Expression) {
   override def equals(we: Any) = we match {
     case (we: WrappedExpression) => (e1,we.e1) match {
-      case (e1: UIntLiteral, e2: UIntLiteral) => e1.value == e2.value && eqw(e1.width, e2.width)
-      case (e1: SIntLiteral, e2: SIntLiteral) => e1.value == e2.value && eqw(e1.width, e2.width)
-      case (e1: WRef, e2: WRef) => e1.name equals e2.name
-      case (e1: WSubField, e2: WSubField) => (e1.name equals e2.name) && weq(e1.exp,e2.exp)
-      case (e1: WSubIndex, e2: WSubIndex) => (e1.value == e2.value) && weq(e1.exp,e2.exp)
-      case (e1: WSubAccess, e2: WSubAccess) => weq(e1.index,e2.index) && weq(e1.exp,e2.exp)
+      case (e1x: UIntLiteral, e2x: UIntLiteral) => e1x.value == e2x.value && eqw(e1x.width, e2x.width)
+      case (e1x: SIntLiteral, e2x: SIntLiteral) => e1x.value == e2x.value && eqw(e1x.width, e2x.width)
+      case (e1x: WRef, e2x: WRef) => e1x.name equals e2x.name
+      case (e1x: WSubField, e2x: WSubField) => (e1x.name equals e2x.name) && weq(e1x.exp,e2x.exp)
+      case (e1x: WSubIndex, e2x: WSubIndex) => (e1x.value == e2x.value) && weq(e1x.exp,e2x.exp)
+      case (e1x: WSubAccess, e2x: WSubAccess) => weq(e1x.index,e2x.index) && weq(e1x.exp,e2x.exp)
       case (WVoid, WVoid) => true
       case (WInvalid, WInvalid) => true
-      case (e1: DoPrim, e2: DoPrim) => e1.op == e2.op &&
-         ((e1.consts zip e2.consts) forall {case (x, y) => x == y}) &&
-         ((e1.args zip e2.args) forall {case (x, y) => weq(x, y)})
-      case (e1: Mux, e2: Mux) => weq(e1.cond,e2.cond) && weq(e1.tval,e2.tval) && weq(e1.fval,e2.fval)
-      case (e1: ValidIf, e2: ValidIf) => weq(e1.cond,e2.cond) && weq(e1.value,e2.value)
-      case (e1, e2) => false
+      case (e1x: DoPrim, e2x: DoPrim) => e1x.op == e2x.op &&
+         ((e1x.consts zip e2x.consts) forall {case (x, y) => x == y}) &&
+         ((e1x.args zip e2x.args) forall {case (x, y) => weq(x, y)})
+      case (e1x: Mux, e2x: Mux) => weq(e1x.cond,e2x.cond) && weq(e1x.tval,e2x.tval) && weq(e1x.fval,e2x.fval)
+      case (e1x: ValidIf, e2x: ValidIf) => weq(e1x.cond,e2x.cond) && weq(e1x.value,e2x.value)
+      case (e1x, e2x) => false
     }
     case _ => false
   }

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -429,8 +429,7 @@ abstract class DefModule extends FirrtlNode with IsDeclaration {
   val name : String
   val ports : Seq[Port]
   protected def serializeHeader(tpe: String): String =
-    s"$tpe $name :" + info.serialize +
-    indent(ports map ("\n" + _.serialize) mkString) + "\n"
+    s"$tpe $name :${info.serialize}${indent(ports.map("\n" + _.serialize).mkString)}\n"
   def mapStmt(f: Statement => Statement): DefModule
   def mapPort(f: Port => Port): DefModule
   def mapString(f: String => String): DefModule

--- a/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/AnnotateMemMacros.scala
@@ -132,7 +132,7 @@ object AnnotateMemMacros extends Pass {
         case Some(maskBits) =>
           m.copy(info = tempInfo.append("maskGran" -> dataBits / maskBits))
       }
-    case s => s map updateStmts(connects)
+    case sx => sx map updateStmts(connects)
   }
 
   def annotateModMems(m: DefModule) = m map updateStmts(getConnects(m))

--- a/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
+++ b/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
@@ -281,7 +281,7 @@ class AnnotateValidMemConfigs(reader: Option[YamlFileReader]) extends Pass {
           case Some(p) => p append m
         }
     }
-    case s => s map updateStmts
+    case sx => sx map updateStmts
   }
 
   def run(c: Circuit) = c copy (modules = c.modules map (_ map updateStmts))

--- a/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
+++ b/src/main/scala/firrtl/passes/AnnotateValidMemConfigs.scala
@@ -9,7 +9,6 @@ import Utils.error
 import AnalysisUtils._
 
 import net.jcazevedo.moultingyaml._
-import net.jcazevedo.moultingyaml.DefaultYamlProtocol._
 import scala.collection.mutable
 import java.io.{File, CharArrayWriter, PrintWriter}
 
@@ -58,7 +57,7 @@ case class SRAMConfig(
     val fieldMap = getClass.getDeclaredFields.map { f => 
       f.setAccessible(true)
       f.getName -> f.get(this)
-    } toMap
+    }.toMap
 
     val fieldDelimiter = """\[.*?\]""".r
     val configOptions = fieldDelimiter.findAllIn(pattern).toList

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -97,10 +97,10 @@ object CheckChirrtl extends Pass {
     def checkChirrtlE(info: Info, mname: String, names: NameSet)(e: Expression): Expression = {
       e match {
         case _: DoPrim | _:Mux | _:ValidIf | _: UIntLiteral =>
-        case e: Reference if !names(e.name) =>
-          errors append new UndeclaredReferenceException(info, mname, e.name)
-        case e: SubAccess => validSubexp(info, mname)(e.expr)
-        case e => e map validSubexp(info, mname)
+        case ex: Reference if !names(ex.name) =>
+          errors append new UndeclaredReferenceException(info, mname, ex.name)
+        case ex: SubAccess => validSubexp(info, mname)(ex.expr)
+        case ex => ex map validSubexp(info, mname)
       }
       (e map checkChirrtlW(info, mname)
          map checkChirrtlT(info, mname)
@@ -117,13 +117,13 @@ object CheckChirrtl extends Pass {
     def checkChirrtlS(minfo: Info, mname: String, names: NameSet)(s: Statement): Statement = {
       val info = get_info(s) match {case NoInfo => minfo case x => x}
       s map checkName(info, mname, names) match {
-        case s: DefMemory =>
-          if (hasFlip(s.dataType)) errors append new MemWithFlipException(info, mname, s.name)
-          if (s.depth <= 0) errors append new NegMemSizeException(info, mname)
-        case s: DefInstance if !moduleNames(s.module) =>
-          errors append new ModuleNotDefinedException(info, mname, s.module)
-        case s: Connect => checkValidLoc(info, mname, s.loc)
-        case s: PartialConnect => checkValidLoc(info, mname, s.loc)
+        case sx: DefMemory =>
+          if (hasFlip(sx.dataType)) errors append new MemWithFlipException(info, mname, sx.name)
+          if (sx.depth <= 0) errors append new NegMemSizeException(info, mname)
+        case sx: DefInstance if !moduleNames(sx.module) =>
+          errors append new ModuleNotDefinedException(info, mname, sx.module)
+        case sx: Connect => checkValidLoc(info, mname, sx.loc)
+        case sx: PartialConnect => checkValidLoc(info, mname, sx.loc)
         case _ => // Do Nothing
       }
       (s map checkChirrtlT(info, mname)

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -78,7 +78,7 @@ object CheckInitialization extends Pass {
               voidDeps += e
             }
             e
-          case e => e map hasVoid
+          case _ => e map hasVoid
         }
         hasVoid(e)
         (void, voidDeps)

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -96,7 +96,7 @@ object CheckInitialization extends Pass {
               voidExprs(nodeRef) = VoidExpr(node, voidDeps)
             }
             node
-          case s => s map checkInitS
+          case sx => sx map checkInitS
         }
       }
       checkInitS(m.body)

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -182,22 +182,22 @@ object CheckHighForm extends Pass {
     def checkHighFormS(minfo: Info, mname: String, names: NameSet)(s: Statement): Statement = {
       val info = get_info(s) match {case NoInfo => minfo case x => x}
       s map checkName(info, mname, names) match {
-        case s: DefMemory =>
-          if (hasFlip(s.dataType))
-            errors append new MemWithFlipException(info, mname, s.name)
-          if (s.depth <= 0)
+        case sx: DefMemory =>
+          if (hasFlip(sx.dataType))
+            errors append new MemWithFlipException(info, mname, sx.name)
+          if (sx.depth <= 0)
             errors append new NegMemSizeException(info, mname)
-        case s: WDefInstance =>
-          if (!moduleNames(s.module))
-            errors append new ModuleNotDefinedException(info, mname, s.module)
+        case sx: WDefInstance =>
+          if (!moduleNames(sx.module))
+            errors append new ModuleNotDefinedException(info, mname, sx.module)
           // Check to see if a recursive module instantiation has occured
-          val childToParent = moduleGraph add (mname, s.module)
+          val childToParent = moduleGraph add (mname, sx.module)
           if (childToParent.nonEmpty)
             errors append new InstanceLoop(info, mname, childToParent mkString "->")
-        case s: Connect => checkValidLoc(info, mname, s.loc)
-        case s: PartialConnect => checkValidLoc(info, mname, s.loc)
-        case s: Print => checkFstring(info, mname, s.string, s.args.length)
-        case s => // Do Nothing
+        case sx: Connect => checkValidLoc(info, mname, sx.loc)
+        case sx: PartialConnect => checkValidLoc(info, mname, sx.loc)
+        case sx: Print => checkFstring(info, mname, sx.string, sx.args.length)
+        case sx => // Do Nothing
       }
       (s map checkHighFormT(info, mname)
          map checkHighFormE(info, mname, names)
@@ -294,10 +294,10 @@ object CheckTypes extends Pass {
     val errors = new Errors()
 
     def passive(t: Type): Boolean = t match {
-      case (_: UIntType |_: SIntType) => true
-      case (t: VectorType) => passive(t.tpe)
-      case (t: BundleType) => t.fields forall (x => x.flip == Default && passive(x.tpe))
-      case (t) => true
+      case _: UIntType |_: SIntType => true
+      case tx: VectorType => passive(tx.tpe)
+      case tx: BundleType => tx.fields forall (x => x.flip == Default && passive(x.tpe))
+      case tx => true
     }
     def check_types_primop(info: Info, mname: String, e: DoPrim) {
       def all_same_type (ls:Seq[Expression]) {
@@ -402,28 +402,28 @@ object CheckTypes extends Pass {
     def check_types_s(minfo: Info, mname: String)(s: Statement): Statement = {
       val info = get_info(s) match { case NoInfo => minfo case x => x }
       s match {
-        case (s: Connect) if wt(s.loc.tpe) != wt(s.expr.tpe) =>
-          errors append new InvalidConnect(info, mname, s.loc.serialize, s.expr.serialize)
-        case (s: PartialConnect) if !bulk_equals(s.loc.tpe, s.expr.tpe, Default, Default) =>
-          errors append new InvalidConnect(info, mname, s.loc.serialize, s.expr.serialize)
-        case (s: DefRegister) => s.tpe match {
-          case AnalogType(w) => errors append new IllegalAnalogDeclaration(info, mname, s.name)
-          case t if (wt(s.tpe) != wt(s.init.tpe)) => errors append new InvalidRegInit(info, mname)
+        case sx: Connect if wt(sx.loc.tpe) != wt(sx.expr.tpe) =>
+          errors append new InvalidConnect(info, mname, sx.loc.serialize, sx.expr.serialize)
+        case sx: PartialConnect if !bulk_equals(sx.loc.tpe, sx.expr.tpe, Default, Default) =>
+          errors append new InvalidConnect(info, mname, sx.loc.serialize, sx.expr.serialize)
+        case sx: DefRegister => sx.tpe match {
+          case AnalogType(w) => errors append new IllegalAnalogDeclaration(info, mname, sx.name)
+          case t if wt(sx.tpe) != wt(sx.init.tpe) => errors append new InvalidRegInit(info, mname)
           case t =>
         }
-        case (s: Conditionally) if wt(s.pred.tpe) != wt(ut) =>
+        case sx: Conditionally if wt(sx.pred.tpe) != wt(ut) =>
           errors append new PredNotUInt(info, mname)
-        case (s: DefNode) => s.value.tpe match {
-          case AnalogType(w) => errors append new IllegalAnalogDeclaration(info, mname, s.name)
-          case t if !passive(s.value.tpe) => errors append new NodePassiveType(info, mname)
+        case sx: DefNode => sx.value.tpe match {
+          case AnalogType(w) => errors append new IllegalAnalogDeclaration(info, mname, sx.name)
+          case t if !passive(sx.value.tpe) => errors append new NodePassiveType(info, mname)
           case t =>
         }
-        case (s: Attach) => 
-          (s.source.tpe, kind(s.source)) match {
+        case sx: Attach =>
+          (sx.source.tpe, kind(sx.source)) match {
             case (AnalogType(w), PortKind | WireKind)  =>
-            case _ => errors append new IllegalAttachSource(info, mname, s.source.serialize)
+            case _ => errors append new IllegalAttachSource(info, mname, sx.source.serialize)
           }
-          (s.exprs foreach) { e =>
+          sx.exprs foreach { e =>
             e.tpe match {
               case _: AnalogType =>
               case _ => errors append new OpNotAnalog(info, mname, e.serialize)
@@ -433,16 +433,16 @@ object CheckTypes extends Pass {
               case _ =>  errors append new IllegalAttachExp(info, mname, e.serialize)
             }
           }
-        case (s: Stop) =>
-          if (wt(s.clk.tpe) != wt(ClockType)) errors append new ReqClk(info, mname)
-          if (wt(s.en.tpe) != wt(ut)) errors append new EnNotUInt(info, mname)
-        case (s: Print) =>
-          if (s.args exists (x => wt(x.tpe) != wt(ut) && wt(x.tpe) != wt(st))) 
+        case sx: Stop =>
+          if (wt(sx.clk.tpe) != wt(ClockType)) errors append new ReqClk(info, mname)
+          if (wt(sx.en.tpe) != wt(ut)) errors append new EnNotUInt(info, mname)
+        case sx: Print =>
+          if (sx.args exists (x => wt(x.tpe) != wt(ut) && wt(x.tpe) != wt(st)))
             errors append new PrintfArgNotGround(info, mname)
-          if (wt(s.clk.tpe) != wt(ClockType)) errors append new ReqClk(info, mname)
-          if (wt(s.en.tpe) != wt(ut)) errors append new EnNotUInt(info, mname)
-        case (s: DefMemory) => s.dataType match {
-          case AnalogType(w) => errors append new IllegalAnalogDeclaration(info, mname, s.name)
+          if (wt(sx.clk.tpe) != wt(ClockType)) errors append new ReqClk(info, mname)
+          if (wt(sx.en.tpe) != wt(ut)) errors append new EnNotUInt(info, mname)
+        case sx: DefMemory => sx.dataType match {
+          case AnalogType(w) => errors append new IllegalAnalogDeclaration(info, mname, sx.name)
           case t =>
         }
         case _ =>
@@ -486,11 +486,11 @@ object CheckGenders extends Pass {
 
     def flip_q(t: Type): Boolean = {
       def flip_rec(t: Type, f: Orientation): Boolean = t match {
-        case (t:BundleType) => t.fields exists (
+        case tx:BundleType => tx.fields exists (
           field => flip_rec(field.tpe, times(f, field.flip))
         )
-        case t: VectorType => flip_rec(t.tpe, f)
-        case t => f == Flip
+        case tx: VectorType => flip_rec(tx.tpe, f)
+        case tx => f == Flip
       }
       flip_rec(t, Default)
     }
@@ -620,10 +620,10 @@ object CheckWidths extends Pass {
     def check_width_s(minfo: Info, mname: String)(s: Statement): Statement = {
       val info = get_info(s) match { case NoInfo => minfo case x => x }
       s map check_width_e(info, mname) map check_width_s(info, mname) match {
-        case Attach(info, source, exprs) => 
+        case Attach(infox, source, exprs) =>
           exprs foreach ( e =>
             if (bitWidth(e.tpe) != bitWidth(source.tpe))
-              errors append new AttachWidthsNotEqual(info, mname, e.serialize, source.serialize)
+              errors append new AttachWidthsNotEqual(infox, mname, e.serialize, source.serialize)
           )
           s
         case _ => s

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -112,13 +112,13 @@ object CheckHighForm extends Pass {
     def checkFstring(info: Info, mname: String, s: StringLit, i: Int) {
       val validFormats = "bdxc"
       val (percent, npercents) = (s.array foldLeft (false, 0)){
-        case ((percent, n), b) if percent && (validFormats contains b) =>
+        case ((percentx, n), b) if percentx && (validFormats contains b) =>
           (false, n + 1)
-        case ((percent, n), b) if percent && b != '%' =>
+        case ((percentx, n), b) if percentx && b != '%' =>
           errors append new BadPrintfException(info, mname, b.toChar)
           (false, n)
-        case ((percent, n), b) =>
-          (if (b == '%') !percent else false /* %% -> percent = false */, n)
+        case ((percentx, n), b) =>
+          (if (b == '%') !percentx else false /* %% -> percentx = false */, n)
       }
       if (percent) errors append new BadPrintfTrailingException(info, mname)
       if (npercents != i) errors append new BadPrintfIncorrectNumException(info, mname)
@@ -132,16 +132,16 @@ object CheckHighForm extends Pass {
 
     def checkHighFormW(info: Info, mname: String)(w: Width): Width = {
       w match {
-        case w: IntWidth if w.width <= 0 =>
+        case wx: IntWidth if wx.width <= 0 =>
           errors append new NegWidthException(info, mname)
-        case w => // Do nothing
+        case wx => // Do nothing
       }
       w
     }
 
     def checkHighFormT(info: Info, mname: String)(t: Type): Type = {
       t match {
-        case t: VectorType if t.size < 0 => 
+        case tx: VectorType if tx.size < 0 =>
           errors append new NegVecSizeException(info, mname)
         case _ => // Do nothing
       }
@@ -158,14 +158,14 @@ object CheckHighForm extends Pass {
 
     def checkHighFormE(info: Info, mname: String, names: NameSet)(e: Expression): Expression = {
       e match {
-        case e: WRef if !names(e.name) =>
-          errors append new UndeclaredReferenceException(info, mname, e.name)
-        case e: UIntLiteral if e.value < 0 =>
+        case ex: WRef if !names(ex.name) =>
+          errors append new UndeclaredReferenceException(info, mname, ex.name)
+        case ex: UIntLiteral if ex.value < 0 =>
           errors append new NegUIntException(info, mname)
-        case e: DoPrim => checkHighFormPrimop(info, mname, e)
+        case ex: DoPrim => checkHighFormPrimop(info, mname, ex)
         case _: WRef | _: UIntLiteral | _: Mux | _: ValidIf =>
-        case e: WSubAccess => validSubexp(info, mname)(e.exp)
-        case e => e map validSubexp(info, mname)
+        case ex: WSubAccess => validSubexp(info, mname)(ex.exp)
+        case ex => ex map validSubexp(info, mname)
       }
       (e map checkHighFormW(info, mname)
          map checkHighFormT(info, mname)

--- a/src/main/scala/firrtl/passes/ConstProp.scala
+++ b/src/main/scala/firrtl/passes/ConstProp.scala
@@ -143,7 +143,7 @@ object ConstProp extends Pass {
         case DoPrim(Leq, Seq(a,b),_,_) if isZero(a) && isUInt(b) => one
         case DoPrim(Gt,  Seq(a,b),_,_) if isZero(a) && isUInt(b) => zero
         case DoPrim(Geq, Seq(a,b),_,_) if isUInt(a) && isZero(b) => one
-        case e => e
+        case ex => ex
       }
     }
 
@@ -176,10 +176,10 @@ object ConstProp extends Pass {
       }
       // Calculates an expression's range of values
       x match {
-        case e: DoPrim =>
-          def r0 = range(e.args.head)
-          def r1 = range(e.args(1))
-          e.op match {
+        case ex: DoPrim =>
+          def r0 = range(ex.args.head)
+          def r1 = range(ex.args(1))
+          ex.op match {
             // Always true
             case Lt  if r0 < r1 => one
             case Leq if r0 <= r1 => one
@@ -190,9 +190,9 @@ object ConstProp extends Pass {
             case Leq if r0 > r1 => zero
             case Gt  if r0 <= r1 => zero
             case Geq if r0 < r1 => zero
-            case _ => e
+            case _ => ex
           }
-        case e => e
+        case ex => ex
       }
     }
     foldIfZeroedArg(foldIfOutsideRange(e))

--- a/src/main/scala/firrtl/passes/InferReadWrite.scala
+++ b/src/main/scala/firrtl/passes/InferReadWrite.scala
@@ -92,14 +92,14 @@ object InferReadWritePass extends Pass {
 
   def replaceExp(repl: Netlist)(e: Expression): Expression =
     e map replaceExp(repl) match {
-      case e: WSubField => repl getOrElse (e.serialize, e)
-      case e => e
+      case ex: WSubField => repl getOrElse (ex.serialize, ex)
+      case ex => ex
     }
 
   def replaceStmt(repl: Netlist)(s: Statement): Statement =
     s map replaceStmt(repl) map replaceExp(repl) match {
       case Connect(_, EmptyExpression, _) => EmptyStmt 
-      case s => s
+      case sx => sx
     }
     
   def inferReadWriteStmt(connects: Connects,
@@ -148,7 +148,7 @@ object InferReadWritePass extends Pass {
         readers = mem.readers filterNot readers,
         writers = mem.writers filterNot writers,
         readwriters = mem.readwriters ++ readwriters)
-    case s => s map inferReadWriteStmt(connects, repl, stmts)
+    case sx => sx map inferReadWriteStmt(connects, repl, stmts)
   }
 
   def inferReadWrite(m: DefModule) = {

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -42,7 +42,7 @@ object InferTypes extends Pass {
 
     def remove_unknowns_w(w: Width): Width = w match {
       case UnknownWidth => VarWidth(namespace.newName("w"))
-      case w => w
+      case wx => wx
     }
 
     def remove_unknowns(t: Type): Type =
@@ -61,28 +61,28 @@ object InferTypes extends Pass {
       }
 
     def infer_types_s(types: TypeMap)(s: Statement): Statement = s match {
-      case s: WDefInstance =>
-        val t = mtypes(s.module)
-        types(s.name) = t
-        s copy (tpe = t)
-      case s: DefWire =>
-        val t = remove_unknowns(s.tpe)
-        types(s.name) = t
-        s copy (tpe = t)
-      case s: DefNode =>
-        val sx = (s map infer_types_e(types)).asInstanceOf[DefNode]
-        val t = remove_unknowns(sx.value.tpe)
-        types(s.name) = t
-        sx map infer_types_e(types)
-      case s: DefRegister =>
-        val t = remove_unknowns(s.tpe)
-        types(s.name) = t
-        s copy (tpe = t) map infer_types_e(types)
-      case s: DefMemory =>
-        val t = remove_unknowns(MemPortUtils.memType(s))
-        types(s.name) = t
-        s copy (dataType = remove_unknowns(s.dataType))
-      case s => s map infer_types_s(types) map infer_types_e(types)
+      case sx: WDefInstance =>
+        val t = mtypes(sx.module)
+        types(sx.name) = t
+        sx copy (tpe = t)
+      case sx: DefWire =>
+        val t = remove_unknowns(sx.tpe)
+        types(sx.name) = t
+        sx copy (tpe = t)
+      case sx: DefNode =>
+        val sxx = (sx map infer_types_e(types)).asInstanceOf[DefNode]
+        val t = remove_unknowns(sxx.value.tpe)
+        types(sx.name) = t
+        sxx map infer_types_e(types)
+      case sx: DefRegister =>
+        val t = remove_unknowns(sx.tpe)
+        types(sx.name) = t
+        sx copy (tpe = t) map infer_types_e(types)
+      case sx: DefMemory =>
+        val t = remove_unknowns(MemPortUtils.memType(sx))
+        types(sx.name) = t
+        sx copy (dataType = remove_unknowns(sx.dataType))
+      case sx => sx map infer_types_s(types) map infer_types_e(types)
     }
 
     def infer_types_p(types: TypeMap)(p: Port): Port = {
@@ -121,29 +121,29 @@ object CInferTypes extends Pass {
       }
 
     def infer_types_s(types: TypeMap)(s: Statement): Statement = s match {
-      case (s: DefRegister) =>
-        types(s.name) = s.tpe
-        s map infer_types_e(types)
-      case (s: DefWire) =>
-        types(s.name) = s.tpe
-        s
-      case (s: DefNode) =>
-        types(s.name) = s.value.tpe
-        s
-      case (s: DefMemory) =>
-        types(s.name) = MemPortUtils.memType(s)
-        s
-      case (s: CDefMPort) =>
-        val t = types getOrElse(s.mem, UnknownType)
-        types(s.name) = t
-        s copy (tpe = t)
-      case (s: CDefMemory) =>
-        types(s.name) = s.tpe
-        s
-      case (s: DefInstance) =>
-        types(s.name) = mtypes(s.module)
-        s
-      case (s) => s map infer_types_s(types) map infer_types_e(types)
+      case sx: DefRegister =>
+        types(sx.name) = sx.tpe
+        sx map infer_types_e(types)
+      case sx: DefWire =>
+        types(sx.name) = sx.tpe
+        sx
+      case sx: DefNode =>
+        types(sx.name) = sx.value.tpe
+        sx
+      case sx: DefMemory =>
+        types(sx.name) = MemPortUtils.memType(sx)
+        sx
+      case sx: CDefMPort =>
+        val t = types getOrElse(sx.mem, UnknownType)
+        types(sx.name) = t
+        sx copy (tpe = t)
+      case sx: CDefMemory =>
+        types(sx.name) = sx.tpe
+        sx
+      case sx: DefInstance =>
+        types(sx.name) = mtypes(sx.module)
+        sx
+      case sx => sx map infer_types_s(types) map infer_types_e(types)
     }
 
     def infer_types_p(types: TypeMap)(p: Port): Port = {

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -42,7 +42,7 @@ object InferTypes extends Pass {
 
     def remove_unknowns_w(w: Width): Width = w match {
       case UnknownWidth => VarWidth(namespace.newName("w"))
-      case w => w
+      case _ => w
     }
 
     def remove_unknowns(t: Type): Type =

--- a/src/main/scala/firrtl/passes/InferTypes.scala
+++ b/src/main/scala/firrtl/passes/InferTypes.scala
@@ -42,7 +42,7 @@ object InferTypes extends Pass {
 
     def remove_unknowns_w(w: Width): Width = w match {
       case UnknownWidth => VarWidth(namespace.newName("w"))
-      case _ => w
+      case w => w
     }
 
     def remove_unknowns(t: Type): Type =

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -82,40 +82,40 @@ object InferWidths extends Pass {
       //;println-all-debug(["After Simplify: [" wx "]"])
       wx map substitute(h) match {
         //;("matched  println-debugvarwidth!")
-        case w: VarWidth => h get w.name match {
-          case None => w
+        case wxx: VarWidth => h get wxx.name match {
+          case None => wxx
           case Some(p) =>
             //;println-debug("Contained!")
-            //;println-all-debug(["Width: " w])
-            //;println-all-debug(["Accessed: " h[name(w)]])
+            //;println-all-debug(["Width: " wxx])
+            //;println-all-debug(["Accessed: " h[name(wxx)]])
             val t = simplify(substitute(h)(p))
-            h(w.name) = t
+            h(wxx.name) = t
             t
         }
-        case w => w
+        case wxx => wxx
         //;println-all-debug(["not varwidth!" w])
       }
     }
 
     def b_sub(h: ConstraintMap)(w: Width): Width = {
       w map b_sub(h) match {
-        case w: VarWidth => h getOrElse (w.name, w)
-        case w => w
+        case wx: VarWidth => h getOrElse (wx.name, wx)
+        case wx => wx
       }
     }
 
     def remove_cycle(n: String)(w: Width): Width = {
       //;println-all-debug(["Removing cycle for " n " inside " w])
       w map remove_cycle(n) match {
-        case w: MaxWidth => MaxWidth(w.args filter {
-          case w: VarWidth => !(n equals w.name)
-          case w => true
+        case wx: MaxWidth => MaxWidth(wx.args filter {
+          case wxx: VarWidth => !(n equals wxx.name)
+          case _ => true
         })
-        case w: MinusWidth => w.arg1 match {
+        case wx: MinusWidth => wx.arg1 match {
           case v: VarWidth if n == v.name => v
-          case v => w
+          case v => wx
         }
-        case w => w
+        case wx => wx
       }
       //;println-all-debug(["After removing cycle for " n ", returning " wx])
     }
@@ -124,8 +124,8 @@ object InferWidths extends Pass {
       var has = false
       def rec(w: Width): Width = {
         w match {
-          case w: VarWidth if w.name == n => has = true
-          case w =>
+          case wx: VarWidth if wx.name == n => has = true
+          case _ =>
         }
         w map rec
       }
@@ -284,18 +284,18 @@ object InferWidths extends Pass {
         else in
 
       def solve(w: Width): Option[BigInt] = w match {
-        case (w: VarWidth) =>
+        case wx: VarWidth =>
           for{
-            v <- h.get(w.name) if !v.isInstanceOf[VarWidth]
+            v <- h.get(wx.name) if !v.isInstanceOf[VarWidth]
             result <- solve(v)
           } yield result
-        case (w: MaxWidth) => reduceOptions(forceNonEmpty(w.args.map(solve), Some(BigInt(0))), max)
-        case (w: MinWidth) => reduceOptions(forceNonEmpty(w.args.map(solve), None), min)
-        case (w: PlusWidth) => map2(solve(w.arg1), solve(w.arg2), {_ + _})
-        case (w: MinusWidth) => map2(solve(w.arg1), solve(w.arg2), {_ - _})
-        case (w: ExpWidth) => map2(Some(BigInt(2)), solve(w.arg1), pow_minus_one)
-        case (w: IntWidth) => Some(w.width)
-        case (w) => println(w); error("Shouldn't be here"); None;
+        case wx: MaxWidth => reduceOptions(forceNonEmpty(wx.args.map(solve), Some(BigInt(0))), max)
+        case wx: MinWidth => reduceOptions(forceNonEmpty(wx.args.map(solve), None), min)
+        case wx: PlusWidth => map2(solve(wx.arg1), solve(wx.arg2), {_ + _})
+        case wx: MinusWidth => map2(solve(wx.arg1), solve(wx.arg2), {_ - _})
+        case wx: ExpWidth => map2(Some(BigInt(2)), solve(wx.arg1), pow_minus_one)
+        case wx: IntWidth => Some(wx.width)
+        case wx => println(wx); error("Shouldn't be here"); None;
       }
 
       solve(w) match {

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -53,25 +53,25 @@ object InferWidths extends Pass {
       })
     }
     def simplify(w: Width): Width = w map simplify match {
-      case (w: MinWidth) => MinWidth(unique((w.args foldLeft Seq[Width]()){
-        case (res, w: MinWidth) => res ++ w.args
-        case (res, w) => res :+ w
+      case wx: MinWidth => MinWidth(unique((wx.args foldLeft Seq[Width]()){
+        case (res, wxx: MinWidth) => res ++ wxx.args
+        case (res, wxx) => res :+ wxx
       }))
-      case (w: MaxWidth) => MaxWidth(unique((w.args foldLeft Seq[Width]()){
-        case (res, w: MaxWidth) => res ++ w.args
-        case (res, w) => res :+ w
+      case wx: MaxWidth => MaxWidth(unique((wx.args foldLeft Seq[Width]()){
+        case (res, wxx: MaxWidth) => res ++ wxx.args
+        case (res, wxx) => res :+ wxx
       }))
-      case (w: PlusWidth) => (w.arg1, w.arg2) match {
+      case wx: PlusWidth => (wx.arg1, wx.arg2) match {
         case (w1: IntWidth, w2 :IntWidth) => IntWidth(w1.width + w2.width)
-        case _ => w
+        case _ => wx
       }
-      case (w: MinusWidth) => (w.arg1, w.arg2) match {
+      case wx: MinusWidth => (wx.arg1, wx.arg2) match {
         case (w1: IntWidth, w2: IntWidth) => IntWidth(w1.width - w2.width)
-        case _ => w
+        case _ => wx
       }
-      case (w: ExpWidth) => w.arg1 match {
-        case (w1: IntWidth) => IntWidth(BigInt((math.pow(2, w1.width.toDouble) - 1).toLong))
-        case (w1) => w
+      case wx: ExpWidth => wx.arg1 match {
+        case w1: IntWidth => IntWidth(BigInt((math.pow(2, w1.width.toDouble) - 1).toLong))
+        case _ => wx
       }
       case _ => w
     }

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -108,7 +108,7 @@ class InlineInstances (transID: TransID) extends Transform {
                  WRef(newName, tpe, WireKind, gen)
               }
               else e
-            case e => e map onExp
+            case ex => ex map onExp
          }
          // Recursive. Inlines tagged instances
          def onStmt(s: Statement): Statement = s match {
@@ -123,7 +123,7 @@ class InlineInstances (transID: TransID) extends Transform {
                     def renameExp(e: Expression): Expression = {
                        e map renameExp match {
                           case WRef(name, tpe, kind, gen) => WRef(rename(name), tpe, kind, gen)
-                          case e => e
+                          case ex => ex
                        }
                     }
                     s map rename map renameStmt map renameExp

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -151,16 +151,16 @@ class InlineInstances (transID: TransID) extends Transform {
                     stmts += renameStmt(instInModule.body)
                     Block(stmts.toSeq)
                  } else s
-               case s => s map onExp map onStmt
+               case sx => sx map onExp map onStmt
             }
          m match {
             case Module(info, name, ports, body) =>
               val mx = Module(info, name, ports, onStmt(body))
               inlinedModules(name) = mx
               mx
-            case m: ExtModule =>
-              inlinedModules(m.name) = m
-              m
+            case mx: ExtModule =>
+              inlinedModules(mx.name) = mx
+              mx
          }
       }
 

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -148,33 +148,33 @@ object LowerTypes extends Pass {
         case _ => Block(create_exps(s.name, s.tpe) map (
           e => DefWire(s.info, loweredName(e), e.tpe)))
       }
-      case s: DefRegister => s.tpe match {
-        case _: GroundType => s map lowerTypesExp(memDataTypeMap, info, mname)
+      case sx: DefRegister => sx.tpe match {
+        case _: GroundType => sx map lowerTypesExp(memDataTypeMap, info, mname)
         case _ =>
-          val es = create_exps(s.name, s.tpe)
-          val inits = create_exps(s.init) map lowerTypesExp(memDataTypeMap, info, mname)
-          val clock = lowerTypesExp(memDataTypeMap, info, mname)(s.clock)
-          val reset = lowerTypesExp(memDataTypeMap, info, mname)(s.reset)
+          val es = create_exps(sx.name, sx.tpe)
+          val inits = create_exps(sx.init) map lowerTypesExp(memDataTypeMap, info, mname)
+          val clock = lowerTypesExp(memDataTypeMap, info, mname)(sx.clock)
+          val reset = lowerTypesExp(memDataTypeMap, info, mname)(sx.reset)
           Block(es zip inits map { case (e, i) =>
-            DefRegister(s.info, loweredName(e), e.tpe, clock, reset, i)
+            DefRegister(sx.info, loweredName(e), e.tpe, clock, reset, i)
           })
       }
       // Could instead just save the type of each Module as it gets processed
-      case s: WDefInstance => s.tpe match {
+      case sx: WDefInstance => sx.tpe match {
         case t: BundleType =>
           val fieldsx = t.fields flatMap (f =>
             create_exps(WRef(f.name, f.tpe, ExpKind, times(f.flip, MALE))) map (
               // Flip because inst genders are reversed from Module type
               e => Field(loweredName(e), swap(to_flip(gender(e))), e.tpe)))
-          WDefInstance(s.info, s.name, s.module, BundleType(fieldsx))
+          WDefInstance(sx.info, sx.name, sx.module, BundleType(fieldsx))
         case _ => error("WDefInstance type should be Bundle!")(info, mname)
       }
-      case s: DefMemory =>
-        memDataTypeMap(s.name) = s.dataType
-        s.dataType match {
-          case _: GroundType => s
-          case _ => Block(create_exps(s.name, s.dataType) map (e =>
-            s copy (name = loweredName(e), dataType = e.tpe)))
+      case sx: DefMemory =>
+        memDataTypeMap(sx.name) = sx.dataType
+        sx.dataType match {
+          case _: GroundType => sx
+          case _ => Block(create_exps(sx.name, sx.dataType) map (e =>
+            sx copy (name = loweredName(e), dataType = e.tpe)))
         }
       // wire foo : { a , b }
       // node x = foo
@@ -183,23 +183,23 @@ object LowerTypes extends Pass {
       // node x_a = foo_a
       // node x_b = foo_b
       // node y = x_a
-      case s: DefNode =>
-        val names = create_exps(s.name, s.value.tpe) map lowerTypesExp(memDataTypeMap, info, mname)
-        val exps = create_exps(s.value) map lowerTypesExp(memDataTypeMap, info, mname)
+      case sx: DefNode =>
+        val names = create_exps(sx.name, sx.value.tpe) map lowerTypesExp(memDataTypeMap, info, mname)
+        val exps = create_exps(sx.value) map lowerTypesExp(memDataTypeMap, info, mname)
         Block(names zip exps map { case (n, e) => DefNode(info, loweredName(n), e) })
-      case s: IsInvalid => kind(s.expr) match {
+      case sx: IsInvalid => kind(sx.expr) match {
         case MemKind =>
-          Block(lowerTypesMemExp(memDataTypeMap, info, mname)(s.expr) map (IsInvalid(info, _)))
-        case _ => s map lowerTypesExp(memDataTypeMap, info, mname)
+          Block(lowerTypesMemExp(memDataTypeMap, info, mname)(sx.expr) map (IsInvalid(info, _)))
+        case _ => sx map lowerTypesExp(memDataTypeMap, info, mname)
       }
-      case s: Connect => kind(s.loc) match {
+      case sx: Connect => kind(sx.loc) match {
         case MemKind =>
-          val exp = lowerTypesExp(memDataTypeMap, info, mname)(s.expr)
-          val locs = lowerTypesMemExp(memDataTypeMap, info, mname)(s.loc)
+          val exp = lowerTypesExp(memDataTypeMap, info, mname)(sx.expr)
+          val locs = lowerTypesMemExp(memDataTypeMap, info, mname)(sx.loc)
           Block(locs map (Connect(info, _, exp)))
-        case _ => s map lowerTypesExp(memDataTypeMap, info, mname)
+        case _ => sx map lowerTypesExp(memDataTypeMap, info, mname)
       }
-      case s => s map lowerTypesExp(memDataTypeMap, info, mname)
+      case sx => sx map lowerTypesExp(memDataTypeMap, info, mname)
     }
   }
 

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -105,8 +105,8 @@ object LowerTypes extends Pass {
       // (Connect/IsInvalid must already have been split to ground types)
       case "data" | "mask" | "rdata" | "wdata" | "wmask" =>
         val loMem = tail match {
-          case Some(e) =>
-            val loMemExp = mergeRef(mem, e)
+          case Some(ex) =>
+            val loMemExp = mergeRef(mem, ex)
             val loMemName = loweredName(loMemExp)
             WRef(loMemName, UnknownType, kind(mem), UNKNOWNGENDER)
           case None => mem

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -53,11 +53,11 @@ object PadWidths extends Pass {
 
   // Recursive. Fixes assignments and register initialization widths
   private def onStmt(s: Statement): Statement = s map onExp match {
-    case s: Connect =>
-      s copy (expr = fixup(width(s.loc))(s.expr))
-    case s: DefRegister =>
-      s copy (init = fixup(width(s.tpe))(s.init))
-    case s => s map onStmt
+    case sx: Connect =>
+      sx copy (expr = fixup(width(sx.loc))(sx.expr))
+    case sx: DefRegister =>
+      sx copy (init = fixup(width(sx.tpe))(sx.init))
+    case _ => s map onStmt
   }
 
   def run(c: Circuit): Circuit = c copy (modules = c.modules map (_ map onStmt))

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -48,7 +48,7 @@ object PadWidths extends Pass {
         ex copy (op = Shlw, args = Seq(fixup(width(ex.tpe))(ex.args.head)))
       case _ => ex
     }
-    case _ => e
+    case ex => ex
   }
 
   // Recursive. Fixes assignments and register initialization widths
@@ -57,7 +57,7 @@ object PadWidths extends Pass {
       sx copy (expr = fixup(width(sx.loc))(sx.expr))
     case sx: DefRegister =>
       sx copy (init = fixup(width(sx.tpe))(sx.init))
-    case _ => s map onStmt
+    case sx => sx map onStmt
   }
 
   def run(c: Circuit): Circuit = c copy (modules = c.modules map (_ map onStmt))

--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -34,21 +34,21 @@ object PadWidths extends Pass {
   private def onExp(e: Expression): Expression = e map onExp match {
     case Mux(cond, tval, fval, tpe) =>
       Mux(cond, fixup(width(tpe))(tval), fixup(width(tpe))(fval), tpe)
-    case e: ValidIf => e copy (value = fixup(width(e.tpe))(e.value))
-    case e: DoPrim => e.op match {
+    case ex: ValidIf => ex copy (value = fixup(width(ex.tpe))(ex.value))
+    case ex: DoPrim => ex.op match {
       case Lt | Leq | Gt | Geq | Eq | Neq | Not | And | Or | Xor |
            Add | Sub | Mul | Div | Rem | Shr =>
         // sensitive ops
-        e map fixup((e.args map width foldLeft 0)(math.max))
+        ex map fixup((ex.args map width foldLeft 0)(math.max))
       case Dshl =>
         // special case as args aren't all same width
-        e copy (op = Dshlw, args = Seq(fixup(width(e.tpe))(e.args.head), e.args(1)))
+        ex copy (op = Dshlw, args = Seq(fixup(width(ex.tpe))(ex.args.head), ex.args(1)))
       case Shl =>
         // special case as arg should be same width as result
-        e copy (op = Shlw, args = Seq(fixup(width(e.tpe))(e.args.head)))
-      case _ => e
+        ex copy (op = Shlw, args = Seq(fixup(width(ex.tpe))(ex.args.head)))
+      case _ => ex
     }
-    case e => e
+    case _ => e
   }
 
   // Recursive. Fixes assignments and register initialization widths

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -60,16 +60,16 @@ object ToWorkingIR extends Pass {
   def name = "Working IR"
 
   def toExp(e: Expression): Expression = e map toExp match {
-    case e: Reference => WRef(e.name, e.tpe, NodeKind, UNKNOWNGENDER)
-    case e: SubField => WSubField(e.expr, e.name, e.tpe, UNKNOWNGENDER)
-    case e: SubIndex => WSubIndex(e.expr, e.value, e.tpe, UNKNOWNGENDER)
-    case e: SubAccess => WSubAccess(e.expr, e.index, e.tpe, UNKNOWNGENDER)
-    case e => e
+    case ex: Reference => WRef(ex.name, ex.tpe, NodeKind, UNKNOWNGENDER)
+    case ex: SubField => WSubField(ex.expr, ex.name, ex.tpe, UNKNOWNGENDER)
+    case ex: SubIndex => WSubIndex(ex.expr, ex.value, ex.tpe, UNKNOWNGENDER)
+    case ex: SubAccess => WSubAccess(ex.expr, ex.index, ex.tpe, UNKNOWNGENDER)
+    case ex => ex // This might look like a case to use case _ => e, DO NOT!
   }
 
   def toStmt(s: Statement): Statement = s map toExp match {
-    case s: DefInstance => WDefInstance(s.info, s.name, s.module, UnknownType)
-    case s => s map toStmt
+    case sx: DefInstance => WDefInstance(sx.info, sx.name, sx.module, UnknownType)
+    case sx => sx map toStmt
   }
 
   def run (c:Circuit): Circuit =
@@ -87,7 +87,7 @@ object PullMuxes extends Pass {
               WSubField(exx.fval, ex.name, ex.tpe, ex.gender), ex.tpe)
            case exx: ValidIf => ValidIf(exx.cond,
               WSubField(exx.value, ex.name, ex.tpe, ex.gender), ex.tpe)
-           case _ => ex
+           case _ => ex  // case exx => exx causes failed tests
          }
          case ex: WSubIndex => ex.exp match {
            case exx: Mux => Mux(exx.cond,
@@ -95,7 +95,7 @@ object PullMuxes extends Pass {
               WSubIndex(exx.fval, ex.value, ex.tpe, ex.gender), ex.tpe)
            case exx: ValidIf => ValidIf(exx.cond,
               WSubIndex(exx.value, ex.value, ex.tpe, ex.gender), ex.tpe)
-           case _ => ex
+           case _ => ex  // case exx => exx causes failed tests
          }
          case ex: WSubAccess => ex.exp match {
            case exx: Mux => Mux(exx.cond,
@@ -103,9 +103,9 @@ object PullMuxes extends Pass {
               WSubAccess(exx.fval, ex.index, ex.tpe, ex.gender), ex.tpe)
            case exx: ValidIf => ValidIf(exx.cond,
               WSubAccess(exx.value, ex.index, ex.tpe, ex.gender), ex.tpe)
-           case _ => ex
+           case _ => ex  // case exx => exx causes failed tests
          }
-         case _ => e
+         case ex => ex
        }
        exxx map pull_muxes_e
      }
@@ -125,26 +125,26 @@ object ExpandConnects extends Pass {
       val genders = collection.mutable.LinkedHashMap[String,Gender]()
       def expand_s(s: Statement): Statement = {
         def set_gender(e: Expression): Expression = e map set_gender match {
-          case (e: WRef) => WRef(e.name, e.tpe, e.kind, genders(e.name))
-          case (e: WSubField) =>
-            val f = get_field(e.exp.tpe, e.name)
-            val genderx = times(gender(e.exp), f.flip)
-            WSubField(e.exp, e.name, e.tpe, genderx)
-          case (e: WSubIndex) => WSubIndex(e.exp, e.value, e.tpe, gender(e.exp))
-          case (e: WSubAccess) => WSubAccess(e.exp, e.index, e.tpe, gender(e.exp))
-          case (e) => e
+          case ex: WRef => WRef(ex.name, ex.tpe, ex.kind, genders(ex.name))
+          case ex: WSubField =>
+            val f = get_field(ex.exp.tpe, ex.name)
+            val genderx = times(gender(ex.exp), f.flip)
+            WSubField(ex.exp, ex.name, ex.tpe, genderx)
+          case ex: WSubIndex => WSubIndex(ex.exp, ex.value, ex.tpe, gender(ex.exp))
+          case ex: WSubAccess => WSubAccess(ex.exp, ex.index, ex.tpe, gender(ex.exp))
+          case ex => ex
         }
         s match {
-          case (s: DefWire) => genders(s.name) = BIGENDER; s
-          case (s: DefRegister) => genders(s.name) = BIGENDER; s
-          case (s: WDefInstance) => genders(s.name) = MALE; s
-          case (s: DefMemory) => genders(s.name) = MALE; s
-          case (s: DefNode) => genders(s.name) = MALE; s
-          case (s: IsInvalid) =>
-            val invalids = (create_exps(s.expr) foldLeft Seq[Statement]())(
+          case sx: DefWire => genders(sx.name) = BIGENDER; sx
+          case sx: DefRegister => genders(sx.name) = BIGENDER; sx
+          case sx: WDefInstance => genders(sx.name) = MALE; sx
+          case sx: DefMemory => genders(sx.name) = MALE; sx
+          case sx: DefNode => genders(sx.name) = MALE; sx
+          case sx: IsInvalid =>
+            val invalids = (create_exps(sx.expr) foldLeft Seq[Statement]())(
                (invalids,  expx) => gender(set_gender(expx)) match {
-                  case BIGENDER => invalids :+ IsInvalid(s.info, expx)
-                  case FEMALE => invalids :+ IsInvalid(s.info, expx)
+                  case BIGENDER => invalids :+ IsInvalid(sx.info, expx)
+                  case FEMALE => invalids :+ IsInvalid(sx.info, expx)
                   case _ => invalids
                }
             )
@@ -153,26 +153,26 @@ object ExpandConnects extends Pass {
                case 1 => invalids.head
                case _ => Block(invalids)
             }
-          case (s: Connect) =>
-            val locs = create_exps(s.loc)
-            val exps = create_exps(s.expr)
+          case sx: Connect =>
+            val locs = create_exps(sx.loc)
+            val exps = create_exps(sx.expr)
             Block((locs zip exps).zipWithIndex map {case ((locx, expx), i) =>
-               get_flip(s.loc.tpe, i, Default) match {
-                  case Default => Connect(s.info, locx, expx)
-                  case Flip => Connect(s.info, expx, locx)
+               get_flip(sx.loc.tpe, i, Default) match {
+                  case Default => Connect(sx.info, locx, expx)
+                  case Flip => Connect(sx.info, expx, locx)
                }
             })
-          case (s: PartialConnect) =>
-            val ls = get_valid_points(s.loc.tpe, s.expr.tpe, Default, Default)
-            val locs = create_exps(s.loc)
-            val exps = create_exps(s.expr)
+          case sx: PartialConnect =>
+            val ls = get_valid_points(sx.loc.tpe, sx.expr.tpe, Default, Default)
+            val locs = create_exps(sx.loc)
+            val exps = create_exps(sx.expr)
             Block(ls map {case (x, y) =>
-              get_flip(s.loc.tpe, x, Default) match {
-                 case Default => Connect(s.info, locs(x), exps(y))
-                 case Flip => Connect(s.info, exps(y), locs(x))
+              get_flip(sx.loc.tpe, x, Default) match {
+                 case Default => Connect(sx.info, locs(x), exps(y))
+                 case Flip => Connect(sx.info, exps(y), locs(x))
               }
             })
-          case (s) => s map expand_s
+          case sx => sx map expand_s
         }
       }
 
@@ -280,8 +280,8 @@ object VerilogWrap extends Pass {
   }
   def vWrapS(s: Statement): Statement = {
     s map vWrapS map vWrapE match {
-      case s: Print => s copy (string = VerilogStringLitHandler.format(s.string))
-      case s => s
+      case sx: Print => sx copy (string = VerilogStringLitHandler.format(sx.string))
+      case sx => sx
     }
   }
 
@@ -295,8 +295,8 @@ object VerilogRename extends Pass {
     if (v_keywords(n)) "%s$".format(n) else n
 
   def verilogRenameE(e: Expression): Expression = e match {
-    case e: WRef => e copy (name = verilogRenameN(e.name))
-    case e => e map verilogRenameE
+    case ex: WRef => ex copy (name = verilogRenameN(ex.name))
+    case ex => ex map verilogRenameE
   }
 
   def verilogRenameS(s: Statement): Statement =
@@ -321,7 +321,7 @@ object VerilogPrep extends Pass {
       case _ => s map buildS(attaches)
     }
     def lowerE(e: Expression): Expression = e match {
-      case _: WRef|_: WSubField if (kind(e) == InstanceKind) => 
+      case _: WRef|_: WSubField if kind(e) == InstanceKind =>
         WRef(LowerTypes.loweredName(e), e.tpe, kind(e), gender(e))
       case _ => e map lowerE
     }
@@ -345,6 +345,6 @@ object VerilogPrep extends Pass {
       m map buildS(attaches)
       m map lowerS(attaches)
     }
-    c copy (modules = (c.modules map prepModule))
+    c.copy(modules = c.modules.map(prepModule))
   }
 }

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -80,34 +80,34 @@ object PullMuxes extends Pass {
    def name = "Pull Muxes"
    def run(c: Circuit): Circuit = {
      def pull_muxes_e(e: Expression): Expression = {
-       val ex = e map pull_muxes_e match {
-         case (e: WSubField) => e.exp match {
-           case (ex: Mux) => Mux(ex.cond,
-              WSubField(ex.tval, e.name, e.tpe, e.gender),
-              WSubField(ex.fval, e.name, e.tpe, e.gender), e.tpe)
-           case (ex: ValidIf) => ValidIf(ex.cond,
-              WSubField(ex.value, e.name, e.tpe, e.gender), e.tpe)
-           case (ex) => e
+       val exxx = e map pull_muxes_e match {
+         case ex: WSubField => ex.exp match {
+           case exx: Mux => Mux(exx.cond,
+              WSubField(exx.tval, ex.name, ex.tpe, ex.gender),
+              WSubField(exx.fval, ex.name, ex.tpe, ex.gender), ex.tpe)
+           case exx: ValidIf => ValidIf(exx.cond,
+              WSubField(exx.value, ex.name, ex.tpe, ex.gender), ex.tpe)
+           case _ => ex
          }
-         case (e: WSubIndex) => e.exp match {
-           case (ex: Mux) => Mux(ex.cond,
-              WSubIndex(ex.tval, e.value, e.tpe, e.gender),
-              WSubIndex(ex.fval, e.value, e.tpe, e.gender), e.tpe)
-           case (ex: ValidIf) => ValidIf(ex.cond,
-              WSubIndex(ex.value, e.value, e.tpe, e.gender), e.tpe)
-           case (ex) => e
+         case ex: WSubIndex => ex.exp match {
+           case exx: Mux => Mux(exx.cond,
+              WSubIndex(exx.tval, ex.value, ex.tpe, ex.gender),
+              WSubIndex(exx.fval, ex.value, ex.tpe, ex.gender), ex.tpe)
+           case exx: ValidIf => ValidIf(exx.cond,
+              WSubIndex(exx.value, ex.value, ex.tpe, ex.gender), ex.tpe)
+           case _ => ex
          }
-         case (e: WSubAccess) => e.exp match {
-           case (ex: Mux) => Mux(ex.cond,
-              WSubAccess(ex.tval, e.index, e.tpe, e.gender),
-              WSubAccess(ex.fval, e.index, e.tpe, e.gender), e.tpe)
-           case (ex: ValidIf) => ValidIf(ex.cond,
-              WSubAccess(ex.value, e.index, e.tpe, e.gender), e.tpe)
-           case (ex) => e
+         case ex: WSubAccess => ex.exp match {
+           case exx: Mux => Mux(exx.cond,
+              WSubAccess(exx.tval, ex.index, ex.tpe, ex.gender),
+              WSubAccess(exx.fval, ex.index, ex.tpe, ex.gender), ex.tpe)
+           case exx: ValidIf => ValidIf(exx.cond,
+              WSubAccess(exx.value, ex.index, ex.tpe, ex.gender), ex.tpe)
+           case _ => ex
          }
-         case (e) => e
+         case _ => e
        }
-       ex map pull_muxes_e
+       exxx map pull_muxes_e
      }
      def pull_muxes(s: Statement): Statement = s map pull_muxes map pull_muxes_e
      val modulesx = c.modules.map {

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -63,8 +63,8 @@ object RemoveAccesses extends Pass {
     var ret: Boolean = false
     def rec_has_access(e: Expression): Expression = {
       e match {
-        case e : WSubAccess => ret = true
-        case e =>
+        case _ : WSubAccess => ret = true
+        case _ =>
       }
       e map rec_has_access
     }

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -149,7 +149,7 @@ object RemoveAccesses extends Pass {
         val sx = s match {
           case Connect(info, loc, exp) =>
             Connect(info, removeFemale(info, fixFemale(loc)), fixMale(exp))
-          case (s) => s map fixMale map onStmt
+          case sxx => sxx map fixMale map onStmt
         }
         stmts += sx
         if (stmts.size != 1) Block(stmts) else stmts(0)

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -70,16 +70,16 @@ object RemoveCHIRRTL extends Pass {
 
   def collect_smems_and_mports(mports: MPortMap, smems: SeqMemSet)(s: Statement): Statement = {
     s match {
-      case (s:CDefMemory) if s.seq => smems += s.name
-      case (s:CDefMPort) =>
-        val p = mports getOrElse (s.mem, EMPs)
-        s.direction match {
-          case MRead => p.readers += MPort(s.name, s.exps(1))
-          case MWrite => p.writers += MPort(s.name, s.exps(1))
-          case MReadWrite => p.readwriters += MPort(s.name, s.exps(1))
+      case sx: CDefMemory if sx.seq => smems += sx.name
+      case sx: CDefMPort =>
+        val p = mports getOrElse (sx.mem, EMPs)
+        sx.direction match {
+          case MRead => p.readers += MPort(sx.name, sx.exps(1))
+          case MWrite => p.writers += MPort(sx.name, sx.exps(1))
+          case MReadWrite => p.readwriters += MPort(sx.name, sx.exps(1))
         }
-        mports(s.mem) = p
-      case s =>
+        mports(sx.mem) = p
+      case _ =>
     }
     s map collect_smems_and_mports(mports, smems)
   }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -86,27 +86,27 @@ object RemoveCHIRRTL extends Pass {
 
   def collect_refs(mports: MPortMap, smems: SeqMemSet, types: MPortTypeMap,
       refs: DataRefMap, raddrs: AddrMap)(s: Statement): Statement = s match {
-    case (s: CDefMemory) =>
-      types(s.name) = s.tpe
-      val taddr = UIntType(IntWidth(1 max ceilLog2(s.size)))
-      val tdata = s.tpe
+    case sx: CDefMemory =>
+      types(sx.name) = sx.tpe
+      val taddr = UIntType(IntWidth(1 max ceilLog2(sx.size)))
+      val tdata = sx.tpe
       def set_poison(vec: Seq[MPort]) = vec flatMap (r => Seq(
-        IsInvalid(s.info, SubField(SubField(Reference(s.name, ut), r.name, ut), "addr", taddr)),
-        IsInvalid(s.info, SubField(SubField(Reference(s.name, ut), r.name, ut), "clk", ClockType))
+        IsInvalid(sx.info, SubField(SubField(Reference(sx.name, ut), r.name, ut), "addr", taddr)),
+        IsInvalid(sx.info, SubField(SubField(Reference(sx.name, ut), r.name, ut), "clk", ClockType))
       ))
       def set_enable(vec: Seq[MPort], en: String) = vec map (r =>
-        Connect(s.info, SubField(SubField(Reference(s.name, ut), r.name, ut), en, BoolType), zero)
+        Connect(sx.info, SubField(SubField(Reference(sx.name, ut), r.name, ut), en, BoolType), zero)
       )
       def set_write(vec: Seq[MPort], data: String, mask: String) = vec flatMap {r =>
-        val tmask = createMask(s.tpe)
-        IsInvalid(s.info, SubField(SubField(Reference(s.name, ut), r.name, ut), data, tdata)) +:
-             (create_exps(SubField(SubField(Reference(s.name, ut), r.name, ut), mask, tmask))
-               map (Connect(s.info, _, zero))
+        val tmask = createMask(sx.tpe)
+        IsInvalid(sx.info, SubField(SubField(Reference(sx.name, ut), r.name, ut), data, tdata)) +:
+             (create_exps(SubField(SubField(Reference(sx.name, ut), r.name, ut), mask, tmask))
+               map (Connect(sx.info, _, zero))
              )
       }
-      val rds = (mports getOrElse (s.name, EMPs)).readers
-      val wrs = (mports getOrElse (s.name, EMPs)).writers
-      val rws = (mports getOrElse (s.name, EMPs)).readwriters
+      val rds = (mports getOrElse (sx.name, EMPs)).readers
+      val wrs = (mports getOrElse (sx.name, EMPs)).writers
+      val rws = (mports getOrElse (sx.name, EMPs)).readwriters
       val stmts = set_poison(rds) ++
         set_enable(rds, "en") ++
         set_poison(wrs) ++
@@ -116,49 +116,49 @@ object RemoveCHIRRTL extends Pass {
         set_enable(rws, "wmode") ++
         set_enable(rws, "en") ++
         set_write(rws, "wdata", "wmask")
-      val mem = DefMemory(s.info, s.name, s.tpe, s.size, 1, if (s.seq) 1 else 0,
+      val mem = DefMemory(sx.info, sx.name, sx.tpe, sx.size, 1, if (sx.seq) 1 else 0,
                   rds map (_.name), wrs map (_.name), rws map (_.name))
       Block(mem +: stmts)
-    case (s: CDefMPort) =>
-      types(s.name) = types(s.mem)
+    case sx: CDefMPort =>
+      types(sx.name) = types(sx.mem)
       val addrs = ArrayBuffer[String]()
       val clks = ArrayBuffer[String]()
       val ens = ArrayBuffer[String]()
-      s.direction match {
+      sx.direction match {
         case MReadWrite =>
-          refs(s.name) = DataRef(SubField(Reference(s.mem, ut), s.name, ut), "rdata", "wdata", "wmask", rdwrite = true)
+          refs(sx.name) = DataRef(SubField(Reference(sx.mem, ut), sx.name, ut), "rdata", "wdata", "wmask", rdwrite = true)
           addrs += "addr"
           clks += "clk"
           ens += "en"
         case MWrite =>
-          refs(s.name) = DataRef(SubField(Reference(s.mem, ut), s.name, ut), "data", "data", "mask", rdwrite = false)
+          refs(sx.name) = DataRef(SubField(Reference(sx.mem, ut), sx.name, ut), "data", "data", "mask", rdwrite = false)
           addrs += "addr"
           clks += "clk"
           ens += "en"
         case MRead =>
-          refs(s.name) = DataRef(SubField(Reference(s.mem, ut), s.name, ut), "data", "data", "blah", rdwrite = false)
+          refs(sx.name) = DataRef(SubField(Reference(sx.mem, ut), sx.name, ut), "data", "data", "blah", rdwrite = false)
           addrs += "addr"
           clks += "clk"
-          s.exps.head match {
-            case e: Reference if smems(s.mem) =>
-              raddrs(e.name) = SubField(SubField(Reference(s.mem, ut), s.name, ut), "en", ut)
+          sx.exps.head match {
+            case e: Reference if smems(sx.mem) =>
+              raddrs(e.name) = SubField(SubField(Reference(sx.mem, ut), sx.name, ut), "en", ut)
             case _ => ens += "en"
           }
       }
       Block(
-        (addrs map (x => Connect(s.info, SubField(SubField(Reference(s.mem, ut), s.name, ut), x, ut), s.exps.head))) ++
-        (clks map (x => Connect(s.info, SubField(SubField(Reference(s.mem, ut), s.name, ut), x, ut), s.exps(1)))) ++
-        (ens map (x => Connect(s.info,SubField(SubField(Reference(s.mem,ut), s.name, ut), x, ut), one))))
-    case (s) => s map collect_refs(mports, smems, types, refs, raddrs)
+        (addrs map (x => Connect(sx.info, SubField(SubField(Reference(sx.mem, ut), sx.name, ut), x, ut), sx.exps.head))) ++
+        (clks map (x => Connect(sx.info, SubField(SubField(Reference(sx.mem, ut), sx.name, ut), x, ut), sx.exps(1)))) ++
+        (ens map (x => Connect(sx.info,SubField(SubField(Reference(sx.mem,ut), sx.name, ut), x, ut), one))))
+    case sx => sx map collect_refs(mports, smems, types, refs, raddrs)
   }
 
   def get_mask(refs: DataRefMap)(e: Expression): Expression =
     e map get_mask(refs) match {
-      case e: Reference => refs get e.name match {
-        case None => e
-        case Some(p) => SubField(p.exp, p.mask, createMask(e.tpe))
+      case ex: Reference => refs get ex.name match {
+        case None => ex
+        case Some(p) => SubField(p.exp, p.mask, createMask(ex.tpe))
       }
-      case e => e
+      case ex => ex
     }
 
   def remove_chirrtl_s(refs: DataRefMap, raddrs: AddrMap)(s: Statement): Statement = {
@@ -185,7 +185,7 @@ object RemoveCHIRRTL extends Pass {
       }
       case SubAccess(expr, index, tpe)  => SubAccess(
         remove_chirrtl_e(g)(expr), remove_chirrtl_e(MALE)(index), tpe)
-      case e => e map remove_chirrtl_e(g)
+      case ex => ex map remove_chirrtl_e(g)
    }
    s match {
       case DefNode(info, name, value) =>
@@ -234,7 +234,7 @@ object RemoveCHIRRTL extends Pass {
           }
         }
         if (stmts.isEmpty) sx else Block(sx +: stmts)
-      case s => s map remove_chirrtl_s(refs, raddrs) map remove_chirrtl_e(MALE)
+      case sx => sx map remove_chirrtl_s(refs, raddrs) map remove_chirrtl_e(MALE)
     }
   }
 

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -50,19 +50,19 @@ object RemoveCHIRRTL extends Pass {
   type AddrMap = collection.mutable.HashMap[String, Expression]
 
   def create_exps(e: Expression): Seq[Expression] = e match {
-    case (e: Mux) =>
-      val e1s = create_exps(e.tval)
-      val e2s = create_exps(e.fval)
-      (e1s zip e2s) map { case (e1, e2) => Mux(e.cond, e1, e2, mux_type(e1, e2)) }
-    case (e: ValidIf) =>
-      create_exps(e.value) map (e1 => ValidIf(e.cond, e1, e1.tpe))
-    case (e) => e.tpe match {
-      case (_: GroundType) => Seq(e)
-      case (t: BundleType) => (t.fields foldLeft Seq[Expression]())((exps, f) =>
-        exps ++ create_exps(SubField(e, f.name, f.tpe)))
-      case (t: VectorType) => ((0 until t.size) foldLeft Seq[Expression]())((exps, i) =>
-        exps ++ create_exps(SubIndex(e, i, t.tpe)))
-      case UnknownType => Seq(e)
+    case ex: Mux =>
+      val e1s = create_exps(ex.tval)
+      val e2s = create_exps(ex.fval)
+      (e1s zip e2s) map { case (e1, e2) => Mux(ex.cond, e1, e2, mux_type(e1, e2)) }
+    case ex: ValidIf =>
+      create_exps(ex.value) map (e1 => ValidIf(ex.cond, e1, e1.tpe))
+    case ex => ex.tpe match {
+      case _: GroundType => Seq(ex)
+      case t: BundleType => (t.fields foldLeft Seq[Expression]())((exps, f) =>
+        exps ++ create_exps(SubField(ex, f.name, f.tpe)))
+      case t: VectorType => ((0 until t.size) foldLeft Seq[Expression]())((exps, i) =>
+        exps ++ create_exps(SubIndex(ex, i, t.tpe)))
+      case UnknownType => Seq(ex)
     }
   }
 

--- a/src/main/scala/firrtl/passes/ReplaceAccesses.scala
+++ b/src/main/scala/firrtl/passes/ReplaceAccesses.scala
@@ -18,8 +18,8 @@ object ReplaceAccesses extends Pass {
   def run(c: Circuit): Circuit = {
     def onStmt(s: Statement): Statement = s map onStmt map onExp
     def onExp(e: Expression): Expression = e match {
-      case WSubAccess(e, UIntLiteral(value, width), t, g) => WSubIndex(e, value.toInt, t, g)
-      case e => e map onExp
+      case WSubAccess(ex, UIntLiteral(value, width), t, g) => WSubIndex(ex, value.toInt, t, g)
+      case _ => e map onExp
     }
   
     c copy (modules = c.modules map (_ map onStmt))

--- a/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/ReplaceMemMacros.scala
@@ -103,7 +103,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Pass {
         case Some(ref: String) =>
           WDefInstance(info, m.name, ref, UnknownType) 
       }
-    case s => s map updateMemStmts(namespace, memPortMap, memMods)
+    case sx => sx map updateMemStmts(namespace, memPortMap, memMods)
   }
 
   def updateMemMods(namespace: Namespace, memMods: Modules)(m: DefModule) = {

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -73,7 +73,7 @@ object ResolveKinds extends Pass {
 object ResolveGenders extends Pass {
   def name = "Resolve Genders"
   def resolve_e(g: Gender)(e: Expression): Expression = e match {
-    case e: WRef => e copy (gender = g)
+    case ex: WRef => ex copy (gender = g)
     case WSubField(exp, name, tpe, _) => WSubField(
       Utils.field_flip(exp.tpe, name) match {
         case Default => resolve_e(g)(exp)
@@ -83,7 +83,7 @@ object ResolveGenders extends Pass {
       WSubIndex(resolve_e(g)(exp), value, tpe, g)
     case WSubAccess(exp, index, tpe, _) =>
       WSubAccess(resolve_e(g)(exp), resolve_e(MALE)(index), tpe, g)
-    case e => e map resolve_e(g)
+    case _ => e map resolve_e(g)
   }
         
   def resolve_s(s: Statement): Statement = s match {

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -41,19 +41,19 @@ object ResolveKinds extends Pass {
 
   def find_stmt(kinds: KindMap)(s: Statement):Statement = {
     s match {
-      case s: DefWire => kinds(s.name) = WireKind
-      case s: DefNode => kinds(s.name) = NodeKind
-      case s: DefRegister => kinds(s.name) = RegKind
-      case s: WDefInstance => kinds(s.name) = InstanceKind
-      case s: DefMemory => kinds(s.name) = MemKind
-      case s =>
+      case sx: DefWire => kinds(sx.name) = WireKind
+      case sx: DefNode => kinds(sx.name) = NodeKind
+      case sx: DefRegister => kinds(sx.name) = RegKind
+      case sx: WDefInstance => kinds(sx.name) = InstanceKind
+      case sx: DefMemory => kinds(sx.name) = MemKind
+      case _ =>
     } 
     s map find_stmt(kinds)
   }
 
   def resolve_expr(kinds: KindMap)(e: Expression): Expression = e match {
-    case e: WRef => e copy (kind = kinds(e.name))
-    case e => e map resolve_expr(kinds)
+    case ex: WRef => ex copy (kind = kinds(ex.name))
+    case _ => e map resolve_expr(kinds)
   }
 
   def resolve_stmt(kinds: KindMap)(s: Statement): Statement =

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -94,7 +94,7 @@ object ResolveGenders extends Pass {
       Connect(info, resolve_e(FEMALE)(loc), resolve_e(MALE)(expr))
     case PartialConnect(info, loc, expr) =>
       PartialConnect(info, resolve_e(FEMALE)(loc), resolve_e(MALE)(expr))
-    case s => s map resolve_e(MALE) map resolve_s
+    case sx => sx map resolve_e(MALE) map resolve_s
   }
 
   def resolve_gender(m: DefModule): DefModule = m map resolve_s
@@ -135,23 +135,23 @@ object CInferMDir extends Pass {
   }
 
   def infer_mdir_s(mports: MPortDirMap)(s: Statement): Statement = s match { 
-    case s: CDefMPort =>
-       mports(s.name) = s.direction
-       s map infer_mdir_e(mports, MRead)
-    case s: Connect =>
-       infer_mdir_e(mports, MRead)(s.expr)
-       infer_mdir_e(mports, MWrite)(s.loc)
-       s
-    case s: PartialConnect =>
-       infer_mdir_e(mports, MRead)(s.expr)
-       infer_mdir_e(mports, MWrite)(s.loc)
-       s
-    case s => s map infer_mdir_s(mports) map infer_mdir_e(mports, MRead)
+    case sx: CDefMPort =>
+       mports(sx.name) = sx.direction
+       sx map infer_mdir_e(mports, MRead)
+    case sx: Connect =>
+       infer_mdir_e(mports, MRead)(sx.expr)
+       infer_mdir_e(mports, MWrite)(sx.loc)
+       sx
+    case sx: PartialConnect =>
+       infer_mdir_e(mports, MRead)(sx.expr)
+       infer_mdir_e(mports, MWrite)(sx.loc)
+       sx
+    case sx => sx map infer_mdir_s(mports) map infer_mdir_e(mports, MRead)
   }
         
   def set_mdir_s(mports: MPortDirMap)(s: Statement): Statement = s match { 
-    case s: CDefMPort => s copy (direction = mports(s.name))
-    case s => s map set_mdir_s(mports)
+    case sx: CDefMPort => sx copy (direction = mports(sx.name))
+    case sx => sx map set_mdir_s(mports)
   }
   
   def infer_mdir(m: DefModule): DefModule = {

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -31,14 +31,14 @@ object SplitExpressions extends Pass {
             val name = namespace.newTemp
             v += DefNode(get_info(s), name, e)
             WRef(name, e.tpe, kind(e), gender(e))
-          case e => e
+          case _ => e
         }
 
         // Recursive. Splits compound nodes
         def onExp(e: Expression): Expression =
           e map onExp match {
             case ex: DoPrim => ex map split
-            case v => v
+            case _ => e
          }
 
         s map onExp match {

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -38,7 +38,7 @@ object SplitExpressions extends Pass {
         def onExp(e: Expression): Expression =
           e map onExp match {
             case ex: DoPrim => ex map split
-            case _ => e
+            case ex => ex
          }
 
         s map onExp match {

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -145,8 +145,8 @@ object Uniquify extends Pass {
       to: Type)
       (implicit sinfo: Info, mname: String): Map[String, NameMapNode] = {
     (from, to) match {
-      case (from: BundleType, to: BundleType) =>
-        (from.fields zip to.fields flatMap { case (f, t) =>
+      case (fromx: BundleType, tox: BundleType) =>
+        (fromx.fields zip tox.fields flatMap { case (f, t) =>
           val eltsMap = createNameMapping(f.tpe, t.tpe)
           if ((f.name != t.name) || eltsMap.nonEmpty) {
             Map(f.name -> NameMapNode(t.name, eltsMap))
@@ -154,10 +154,10 @@ object Uniquify extends Pass {
             Map[String, NameMapNode]()
           }
         }).toMap
-      case (from: VectorType, to: VectorType) =>
-        createNameMapping(from.tpe, to.tpe)
-      case (from, to) =>
-        if (from.getClass == to.getClass) Map()
+      case (fromx: VectorType, tox: VectorType) =>
+        createNameMapping(fromx.tpe, tox.tpe)
+      case (fromx, tox) =>
+        if (fromx.getClass == tox.getClass) Map()
         else error("Types to map between do not match!")
     }
   }
@@ -224,28 +224,28 @@ object Uniquify extends Pass {
   def stmtToType(s: Statement)(implicit sinfo: Info, mname: String): BundleType = {
     // Recursive helper
     def recStmtToType(s: Statement): Seq[Field] = s match {
-      case s: DefWire => Seq(Field(s.name, Default, s.tpe))
-      case s: DefRegister => Seq(Field(s.name, Default, s.tpe))
-      case s: WDefInstance => Seq(Field(s.name, Default, s.tpe))
-      case s: DefMemory => s.dataType match {
+      case sx: DefWire => Seq(Field(sx.name, Default, sx.tpe))
+      case sx: DefRegister => Seq(Field(sx.name, Default, sx.tpe))
+      case sx: WDefInstance => Seq(Field(sx.name, Default, sx.tpe))
+      case sx: DefMemory => sx.dataType match {
         case (_: UIntType | _: SIntType) =>
-          Seq(Field(s.name, Default, memType(s)))
+          Seq(Field(sx.name, Default, memType(sx)))
         case tpe: BundleType =>
           val newFields = tpe.fields map ( f =>
-            DefMemory(s.info, f.name, f.tpe, s.depth, s.writeLatency,
-              s.readLatency, s.readers, s.writers, s.readwriters)
+            DefMemory(sx.info, f.name, f.tpe, sx.depth, sx.writeLatency,
+              sx.readLatency, sx.readers, sx.writers, sx.readwriters)
           ) flatMap recStmtToType
-          Seq(Field(s.name, Default, BundleType(newFields)))
+          Seq(Field(sx.name, Default, BundleType(newFields)))
         case tpe: VectorType =>
           val newFields = (0 until tpe.size) map ( i =>
-            s.copy(name = i.toString, dataType = tpe.tpe)
+            sx.copy(name = i.toString, dataType = tpe.tpe)
           ) flatMap recStmtToType
-          Seq(Field(s.name, Default, BundleType(newFields)))
+          Seq(Field(sx.name, Default, BundleType(newFields)))
       }
-      case s: DefNode => Seq(Field(s.name, Default, s.value.tpe))
-      case s: Conditionally => recStmtToType(s.conseq) ++ recStmtToType(s.alt)
-      case s: Block => (s.stmts map recStmtToType).flatten
-      case s => Seq()
+      case sx: DefNode => Seq(Field(sx.name, Default, sx.value.tpe))
+      case sx: Conditionally => recStmtToType(sx.conseq) ++ recStmtToType(sx.alt)
+      case sx: Block => (sx.stmts map recStmtToType).flatten
+      case sx => Seq()
     }
     BundleType(recStmtToType(s))
   }
@@ -274,53 +274,53 @@ object Uniquify extends Pass {
 
       def uniquifyStmt(s: Statement): Statement = {
         s map uniquifyStmt map uniquifyExp match {
-          case s: DefWire =>
-            sinfo = s.info
-            if (nameMap.contains(s.name)) {
-              val node = nameMap(s.name)
-              DefWire(s.info, node.name, uniquifyNamesType(s.tpe, node.elts))
+          case sx: DefWire =>
+            sinfo = sx.info
+            if (nameMap.contains(sx.name)) {
+              val node = nameMap(sx.name)
+              DefWire(sx.info, node.name, uniquifyNamesType(sx.tpe, node.elts))
             } else {
-              s
+              sx
             }
-          case s: DefRegister =>
-            sinfo = s.info
-            if (nameMap.contains(s.name)) {
-              val node = nameMap(s.name)
-              DefRegister(s.info, node.name, uniquifyNamesType(s.tpe, node.elts),
-                          s.clock, s.reset, s.init)
+          case sx: DefRegister =>
+            sinfo = sx.info
+            if (nameMap.contains(sx.name)) {
+              val node = nameMap(sx.name)
+              DefRegister(sx.info, node.name, uniquifyNamesType(sx.tpe, node.elts),
+                          sx.clock, sx.reset, sx.init)
             } else {
-              s
+              sx
             }
-          case s: WDefInstance =>
-            sinfo = s.info
-            if (nameMap.contains(s.name)) {
-              val node = nameMap(s.name)
-              WDefInstance(s.info, node.name, s.module, s.tpe)
+          case sx: WDefInstance =>
+            sinfo = sx.info
+            if (nameMap.contains(sx.name)) {
+              val node = nameMap(sx.name)
+              WDefInstance(sx.info, node.name, sx.module, sx.tpe)
             } else {
-              s
+              sx
             }
-          case s: DefMemory =>
-            sinfo = s.info
-            if (nameMap.contains(s.name)) {
-              val node = nameMap(s.name)
-              val dataType = uniquifyNamesType(s.dataType, node.elts)
-              val mem = s.copy(name = node.name, dataType = dataType)
+          case sx: DefMemory =>
+            sinfo = sx.info
+            if (nameMap.contains(sx.name)) {
+              val node = nameMap(sx.name)
+              val dataType = uniquifyNamesType(sx.dataType, node.elts)
+              val mem = sx.copy(name = node.name, dataType = dataType)
               // Create new mapping to handle references to memory data fields
-              val uniqueMemMap = createNameMapping(memType(s), memType(mem))
-              nameMap(s.name) = NameMapNode(node.name, node.elts ++ uniqueMemMap)
+              val uniqueMemMap = createNameMapping(memType(sx), memType(mem))
+              nameMap(sx.name) = NameMapNode(node.name, node.elts ++ uniqueMemMap)
               mem
             } else {
-              s
+              sx
             }
-          case s: DefNode =>
-            sinfo = s.info
-            if (nameMap.contains(s.name)) {
-              val node = nameMap(s.name)
-              DefNode(s.info, node.name, s.value)
+          case sx: DefNode =>
+            sinfo = sx.info
+            if (nameMap.contains(sx.name)) {
+              val node = nameMap(sx.name)
+              DefNode(sx.info, node.name, sx.value)
             } else {
-              s
+              sx
             }
-          case s => s
+          case sx => sx
         }
       }
 

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -104,9 +104,9 @@ object Uniquify extends Pass {
       namespace: collection.mutable.HashSet[String])
       (implicit sinfo: Info, mname: String): BundleType = {
     def recUniquifyNames(t: Type, namespace: collection.mutable.HashSet[String]): Type = t match {
-      case t: BundleType =>
+      case tx: BundleType =>
         // First add everything
-        val newFields = t.fields map { f =>
+        val newFields = tx.fields map { f =>
           val newName = findValidPrefix(f.name, Seq(""), namespace)
           namespace += newName
           Field(newName, f.flip, f.tpe)
@@ -128,13 +128,13 @@ object Uniquify extends Pass {
           }
         }
         BundleType(newFields)
-      case t: VectorType =>
-        VectorType(recUniquifyNames(t.tpe, namespace), t.size)
-      case t => t
+      case tx: VectorType =>
+        VectorType(recUniquifyNames(tx.tpe, namespace), tx.size)
+      case tx => tx
     }
     recUniquifyNames(t, namespace) match {
-      case t: BundleType => t
-      case t => error("Shouldn't be here")
+      case tx: BundleType => tx
+      case tx => error("Shouldn't be here")
     }
   }
 

--- a/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
+++ b/src/main/scala/firrtl/passes/UpdateDuplicateMemMacros.scala
@@ -115,7 +115,7 @@ object MemTransformUtils {
     def updateStmtRefs(s: Statement): Statement =
       s map updateStmtRefs map updateRef match {
         case c: Connect if hasEmptyExpr(c) => EmptyStmt
-        case s => s
+        case sx => sx
       }
 
     updateStmtRefs(s)
@@ -140,7 +140,7 @@ object UpdateDuplicateMemMacros extends Pass {
         case Some(proto) =>
           updatedMem copy (info = appendInfo(updatedMem.info, "ref" -> proto.name))
       }
-    case s => s map updateMemStmts(uniqueMems, memPortMap)
+    case sx => sx map updateMemStmts(uniqueMems, memPortMap)
   }
 
   def updateMemMods(m: DefModule) = {


### PR DESCRIPTION
With a couple of minor exceptions this take is just about fixing the shadowing of variables in match statements.  The general strategy is simply to append an x to the variable name for each level of match
```scala
  e match {
    case ex: A => ex match {
      case exx: B =>
```
The dangerous cases seemed to center on usages like
```scala
  e map f(x) match {
    case e: A =>
      ...
    case e => e
```
It is tempting to map that last line to ```case _ => e``` but this tended to spectacularly blow up the test harness.  I have, to a fault, settled on converting it to `case ex => ex