### PR TITLE
Fix RemoveCHIRRTL for unused memory ports

### DIFF
--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -77,6 +77,7 @@ object RemoveCHIRRTL extends Pass {
           case MRead => p.readers += MPort(s.name, s.exps(1))
           case MWrite => p.writers += MPort(s.name, s.exps(1))
           case MReadWrite => p.readwriters += MPort(s.name, s.exps(1))
+          case MInfer => // direction may not be inferred if it's not being used
         }
         mports(s.mem) = p
       case s =>
@@ -144,6 +145,7 @@ object RemoveCHIRRTL extends Pass {
               raddrs(e.name) = SubField(SubField(Reference(s.mem, ut), s.name, ut), "en", ut)
             case _ => ens += "en"
           }
+        case MInfer => // do nothing if it's not being used
       }
       Block(
         (addrs map (x => Connect(s.info, SubField(SubField(Reference(s.mem, ut), s.name, ut), x, ut), s.exps.head))) ++

--- a/src/test/resources/features/EmptyChirrtlMem.fir
+++ b/src/test/resources/features/EmptyChirrtlMem.fir
@@ -1,0 +1,5 @@
+circuit Queue :
+  module Queue :
+    input clock : Clock
+    cmem ram : UInt<1>[2]
+    infer mport T_107 = ram[UInt(0)], clock

--- a/src/test/scala/firrtlTests/ChirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/ChirrtlSpec.scala
@@ -94,6 +94,9 @@ class ChirrtlSpec extends FirrtlFlatSpec {
     }
   }
 
+  it should "compile" in {
+    compileFirrtlTest("EmptyChirrtlMem", "/features")
+  }
   it should "compile and run" in {
     runFirrtlTest("ChirrtlMems", "/features")
   }


### PR DESCRIPTION
This addresses #325.

@aswaterman 
Memory port directions were not inferred during CInferMDir if not being used, which was not accepted in RemoveCHIRRTL.
