### PR TITLE
Add test for Firrtl mems with no ports

### DIFF
--- a/src/test/resources/features/ZeroPortMem.fir
+++ b/src/test/resources/features/ZeroPortMem.fir
@@ -1,0 +1,23 @@
+
+circuit ZeroPortMem :
+  module ZeroPortMem :
+    input clk : Clock
+    input reset : UInt<1>
+
+    mem mymem :
+      data-type => UInt<32>
+      depth => 128
+      read-latency => 0
+      write-latency => 1
+      read-under-write => undefined
+
+    wire foo : UInt<32>
+    foo <= UInt<32>("hdeadbeef")
+
+    when not(reset) :
+      when eq(foo, UInt<32>("hdeadbeef")) :
+        stop(clk, UInt(1), 0) ; Success !
+      else :
+        printf(clk, UInt(1), "Assertion failed!\n")
+        stop(clk, UInt(1), 1) ; Failure!
+

--- a/src/test/scala/firrtlTests/MemSpec.scala
+++ b/src/test/scala/firrtlTests/MemSpec.scala
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2014 - 2016 The Regents of the University of
+California (Regents). All Rights Reserved.  Redistribution and use in
+source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+   * Redistributions of source code must retain the above
+     copyright notice, this list of conditions and the following
+     two paragraphs of disclaimer.
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     two paragraphs of disclaimer in the documentation and/or other materials
+     provided with the distribution.
+   * Neither the name of the Regents nor the names of its contributors
+     may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+*/
+
+package firrtlTests
+
+class MemSpec extends FirrtlPropSpec {
+
+  property("Zero-ported mems should be supported!") {
+    runFirrtlTest("ZeroPortMem", "/features")
+  }
+}
+


### PR DESCRIPTION
Inspired by #325 and #326 

Turns out the Parser and VerilogCompiler are just fine with an empty memory. This test passes.

It really is just a compilation test but I figured it might as well check that the Verilog generated is fine too.