### PR TITLE
fix duplicate memory detection

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/ResolveMaskGranularity.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMaskGranularity.scala
@@ -77,7 +77,8 @@ object AnalysisUtils {
 
   /** Checks whether the two memories are equivalent in all respects except name
     */
-  def eqMems(a: DefAnnotatedMemory, b: DefAnnotatedMemory) = a == b.copy(name = a.name) 
+  def eqMems(a: DefAnnotatedMemory, b: DefAnnotatedMemory) =
+    a == b.copy(info = a.info, name = a.name, memRef = a.memRef)
 }
 
 /** Determines if a write mask is needed (wmode/en and wmask are equivalent).

--- a/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
+++ b/src/main/scala/firrtl/passes/memlib/ResolveMemoryReference.scala
@@ -29,10 +29,8 @@ object ResolveMemoryReference extends Pass {
     case s => s map updateMemStmts(uniqueMems)
   }
 
-  def updateMemMods(m: DefModule) = {
+  def run(c: Circuit) = {
     val uniqueMems = new AnnotatedMemories
-    (m map updateMemStmts(uniqueMems))
+    c copy (modules = c.modules map (_ map updateMemStmts(uniqueMems)))
   }
-
-  def run(c: Circuit) = c copy (modules = c.modules map updateMemMods)
 }


### PR DESCRIPTION
Addresses #333: `uniqueueMems` should be constructed in terms of the entire circuit.

@shunshou I might have changed the algorithm with my refactoring. Also `eqMems` changes in accordance with the recent refactoring.