### PR TITLE
revert the last commit of #346

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/MemUtils.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemUtils.scala
@@ -27,7 +27,7 @@ object toBits {
     case t => error("Invalid operand expression for toBits!")
   }
   private def hiercat(e: Expression): Expression = e.tpe match {
-    case t: VectorType => seqCat((0 until t.size).reverse map (i =>
+    case t: VectorType => seqCat((0 until t.size) map (i =>
       hiercat(WSubIndex(e, i, t.tpe, UNKNOWNGENDER))))
     case t: BundleType => seqCat(t.fields map (f =>
       hiercat(WSubField(e, f.name, f.tpe, UNKNOWNGENDER))))
@@ -58,7 +58,7 @@ object toBitMask {
   private def hiermask(mask: Expression, dataType: Type): Expression =
     (mask.tpe, dataType) match {
       case (mt: VectorType, dt: VectorType) =>
-        seqCat((0 until mt.size).reverse map { i =>
+        seqCat((0 until mt.size) map { i =>
           hiermask(WSubIndex(mask, i, mt.tpe, UNKNOWNGENDER), dt.tpe)
         })
       case (mt: BundleType, dt: BundleType) =>


### PR DESCRIPTION
@colinschmidt @ccelio @shunshou 
Turns out that #346 breaks rocket-chip because Chisel assumes Vec(0) is MSB when a mask is given as UInt.(Or rocket-chip's behavioral mem model is broken if it's not). We should fix Chisel if we don't like concat order, or merge this PR.