### PR TITLE
bug fix for mems

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -94,7 +94,6 @@ object VerilogMemDelays extends Pass {
               val condn = namespace newName s"${LowerTypes.loweredName(e)}_en"
               val condx = WRef(condn, BoolType, NodeKind, FEMALE)
               Seq(DefNode(NoInfo, condn, cond),
-                  Connect(NoInfo, condx, cond),
                   Connect(NoInfo, exx, Mux(condx, ex, exx, e.tpe)))
             })
           )


### PR DESCRIPTION
This removes a spurious connect statement generated by the VerilogMemDelays pass. After the following ConstProp pass, this can turn into an identity assignment (T_880 <= T_880), and this cyclic dependency can cause problems. The current Verilog emitter inadvertently hides this bug since its use of mutable state overwrites this bogus assignment.