### PR TITLE
Add Legalize to MiddleToLowFirrtl

### DIFF
--- a/spec/future-release.txt
+++ b/spec/future-release.txt
@@ -4,3 +4,4 @@ Change tail -> drop
 Add ranges as a 'width' instead of actually declaring width.
   proposed syntax: wire x: UInt{0,10}
 Add Analog type, and 'attach' statement (see #87)
+Add constraints to low firrtl that assignments are same width, etc.

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -127,7 +127,8 @@ class MiddleFirrtlToLowFirrtl extends Transform with SimpleRun {
     passes.InferTypes,
     passes.ResolveGenders,
     passes.InferWidths,
-    passes.ConvertFixedToSInt)
+    passes.ConvertFixedToSInt,
+    passes.Legalize)
   def execute(circuit: Circuit, annotationMap: AnnotationMap): TransformResult =
     run(circuit, passSeq)
 }


### PR DESCRIPTION
Allows the firrtl interpreter to rely on equal width assigns.