### PR TITLE
Clock List Transform

### DIFF
--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -5,6 +5,7 @@ package firrtl
 import firrtl.Annotations._
 import firrtl.Parser._
 import firrtl.passes.memlib.{InferReadWriteAnnotation, ReplSeqMemAnnotation}
+import firrtl.passes.clocklist.ClockListAnnotation
 import logger.LogLevel
 import scopt.OptionParser
 
@@ -289,6 +290,19 @@ trait HasFirrtlOptions {
     }
     .text {
       "Replace sequential memories with blackboxes + configuration file"
+    }
+
+  parser.opt[String]("list-clocks")
+    .abbr("clks")
+    .valueName ("-c:<circuit>:-m:<module>:-o:<filename>")
+    .foreach { x =>
+      firrtlOptions = firrtlOptions.copy(
+        annotations = firrtlOptions.annotations :+ ClockListAnnotation(x),
+        customTransforms = firrtlOptions.customTransforms :+ new passes.clocklist.ClockListTransform
+      )
+    }
+    .text {
+      "List which signal drives each clock of every descendent of specified module"
     }
 
   parser.note("")

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -126,7 +126,22 @@ class LowFirrtlCompiler extends Compiler {
 
 /** Emits Verilog */
 class VerilogCompiler extends Compiler {
+//<<<<<<< HEAD
   def emitter = new VerilogEmitter
   def transforms: Seq[Transform] =
     getLoweringTransforms(ChirrtlForm, LowForm) :+ (new LowFirrtlOptimization)
+//=======
+//  def transforms(writer: Writer): Seq[Transform] = Seq(
+//    new Chisel3ToHighFirrtl,
+//    new IRToWorkingIR,
+//    new ResolveAndCheck,
+//    new HighFirrtlToMiddleFirrtl,
+//    new passes.InferReadWrite(TransID(-1)),
+//    new passes.memlib.ReplSeqMem(TransID(-2)),
+//    new MiddleFirrtlToLowFirrtl,
+//    new passes.clocklist.ClockListTransform(TransID(-3)),
+//    new passes.InlineInstances(TransID(0)),
+//    new EmitVerilogFromLowFirrtl(writer)
+//  )
+//>>>>>>> Added clocklist transform
 }

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -126,22 +126,7 @@ class LowFirrtlCompiler extends Compiler {
 
 /** Emits Verilog */
 class VerilogCompiler extends Compiler {
-//<<<<<<< HEAD
   def emitter = new VerilogEmitter
   def transforms: Seq[Transform] =
     getLoweringTransforms(ChirrtlForm, LowForm) :+ (new LowFirrtlOptimization)
-//=======
-//  def transforms(writer: Writer): Seq[Transform] = Seq(
-//    new Chisel3ToHighFirrtl,
-//    new IRToWorkingIR,
-//    new ResolveAndCheck,
-//    new HighFirrtlToMiddleFirrtl,
-//    new passes.InferReadWrite(TransID(-1)),
-//    new passes.memlib.ReplSeqMem(TransID(-2)),
-//    new MiddleFirrtlToLowFirrtl,
-//    new passes.clocklist.ClockListTransform(TransID(-3)),
-//    new passes.InlineInstances(TransID(0)),
-//    new EmitVerilogFromLowFirrtl(writer)
-//  )
-//>>>>>>> Added clocklist transform
 }

--- a/src/main/scala/firrtl/passes/clocklist/ClockList.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockList.scala
@@ -1,0 +1,191 @@
+package firrtl.passes
+package clocklist
+
+import firrtl._
+import firrtl.ir._
+import Annotations._
+import Utils.error
+import java.io.{File, CharArrayWriter, PrintWriter, Writer}
+import wiring.WiringUtils.{getChildrenMap, countInstances, ChildrenMap}
+import ClockListUtils._
+import Utils._
+import memlib.AnalysisUtils._
+import memlib._
+import Mappers._
+
+/** A lineage tree representing the instance hierarchy in a design
+  */
+case class Lineage(
+    name: String,
+    children: Seq[(String, Lineage)] = Seq.empty,
+    values: Map[Any, Any] = Map.empty) {
+
+  def map(f: Lineage => Lineage): Lineage =
+    this.copy(children = children.map{ case (i, m) => (i, f(m)) })
+
+  def foldLeft[B](z: B)(op: (B, (String, Lineage)) => B): B = 
+    this.children.foldLeft(z)(op)
+
+  override def toString: String = serialize("")
+
+  def serialize(tab: String): String = s"""
+    |$tab name: $name,
+    |$tab map: $values,
+    |$tab children: ${children.map(c => tab + "   " + c._2.serialize(tab + "    "))}
+    |""".stripMargin
+}
+
+class ClockListTransform(transID: TransID) extends Transform {
+  def passSeq(top: String, writer: Writer): Seq[Pass] =
+    Seq(new ClockList(top, writer))
+  def execute(c: Circuit, map: AnnotationMap) = map get transID match {
+    case Some(p) => (p.toSeq.collect { case (ModuleName(m, CircuitName(c.main)), cla) =>
+      cla match {
+        case x: ClockListAnnotation => (m, x.outputConfig)
+        case _ => error(s"Found an unexpected annotation: $cla")
+      }
+    }) match {
+      case Seq((top, out)) => 
+        val outputFile = new PrintWriter(out)
+        val newC = (new ClockList(top, outputFile)).run(c)
+        outputFile.close()
+        TransformResult(newC)
+      case _ => error(s"Found too many (or too few) ClockListAnnotations!")
+    }
+    case None => TransformResult(c)
+  }
+}
+
+case class ClockListAnnotation(t: String, tID: TransID)
+    extends Annotation with Loose with Unstable {
+
+  val usage = """
+[Optional] ClockList
+  List which signal drives each clock of every descendent of specified module
+
+Usage: 
+  --list-clocks -c:<circuit>:-m:<module>:-o:<filename>
+  *** Note: sub-arguments to --list-clocks should be delimited by : and not white space!
+"""    
+
+  //Parse pass options
+  val passOptions = PassConfigUtil.getPassOptions(t, usage)
+  val outputConfig = passOptions.getOrElse(
+    OutputConfigFileName, 
+    error("No output config file provided for ClockList!" + usage)
+  )
+  val passCircuit = passOptions.getOrElse(
+    PassCircuitName, 
+    error("No circuit name specified for ClockList!" + usage)
+  )
+  val passModule = passOptions.getOrElse(
+    PassModuleName, 
+    error("No module name specified for ClockList!" + usage)
+  )
+  passOptions.get(InputConfigFileName) match {
+    case Some(x) => error("Unneeded input config file name!" + usage)
+    case None =>
+  }
+  val target = ModuleName(passModule, CircuitName(passCircuit))
+  def duplicate(n: Named) = n match {
+    case ModuleName(m, CircuitName(c)) => this copy (t = t.replace(s"-c:$passCircuit", s"-c:$c").replace(s"-m:$passModule", s"-m:$m"))
+    case _ => error("Cannot move ClockListAnnotation to a non-module")
+  }
+}
+
+object ClockListUtils {
+  /** Returns a module's lineage, containing all children lineages as well */
+  def getLineage(childrenMap: ChildrenMap, module: String): Lineage =
+    Lineage(module, childrenMap(module) map (c => (c._1, getLineage(childrenMap, c._2))))
+
+  def getModules(set: Set[String], lin: Lineage): Set[String] = {
+    val childSet = lin.foldLeft(set) { case (s, (i, l)) => getModules(s, l) }
+    childSet + lin.name
+  }
+
+  def getLists(moduleMap: Map[String, DefModule])(lin: Lineage): (Seq[String], Seq[String]) = {
+    //println(s"On ${lin.name}")
+    val (c, s) = lin.foldLeft((Seq[String](), Seq[String]())){case ((cL, sL), (i, l)) =>
+      //println(s"At child ${l.name}")
+      val (cLx, sLx) = getLists(moduleMap)(l)
+      val cLxx = cLx map (i + "$" + _)
+      val sLxx = sLx map (i + "$" + _)
+      (cL ++ cLxx, sL ++ sLxx)
+    }
+    val clockList = moduleMap(lin.name) match {
+      case Module(i, n, ports, b) => ports.filter(p => p.name == "clock").map(_.name)
+      case _ => Nil
+    }
+    val sourceList = moduleMap(lin.name) match {
+      case ExtModule(i, n, ports, dn, p) =>
+        val portExps = ports.flatMap{p => create_exps(WRef(p.name, p.tpe, PortKind, to_gender(p.direction)))}
+        portExps.filter(e => (e.tpe == ClockType) && (gender(e) == FEMALE)).map(e => e.serialize)
+      case _ => Nil
+    }
+    val (cx, sx) = (c ++ clockList, s ++ sourceList)
+    //println(s"From ${lin.name}, returning clocklist $cx and sourcelist $sx")
+    (cx, sx)
+  }
+}
+
+class ClockList(top: String, writer: Writer) extends Pass {
+  def name = this.getClass.getSimpleName
+  def run(c: Circuit): Circuit = {
+    // Assume blackbox output is the only clocks we care about
+    // If a module has a single input clock, it is in that clock domain
+    // All reg/mem's in a module must be connected to input "clock" or "clk" or whatever
+    val childrenMap = getChildrenMap(c)
+    val moduleMap = c.modules.foldLeft(Map[String, DefModule]())((map, m) => map + (m.name -> m))
+    val outputBuffer = new CharArrayWriter
+
+    // === Checks ===
+
+    // Stuff
+    val lineages = getLineage(childrenMap, top)
+    val (clockList, partialSourceList) = getLists(moduleMap)(lineages)
+    val sourceList = partialSourceList ++ moduleMap(top).ports.collect{ case Port(i, n, Input, ClockType) => n }
+    writer.append(s"Clocklist: $clockList \n")
+    writer.append(s"Sourcelist: $sourceList \n")
+
+    // Inline all non-black-boxes
+    val inline = new InlineInstances(TransID(-10)) //TID doesn't matter
+    val modulesToInline = (c.modules.collect { case Module(_, n, _, _) if n != top => ModuleName(n, CircuitName(c.main)) }).toSet
+    //val modulesToInline = (getModules(Set[String](), lineages) - top).map(m => ModuleName(m, CircuitName(c.main)))
+    val cx = inline.run(RemoveAllButClocks.run(c), modulesToInline, Set()).circuit
+    val topModule = cx.modules.collectFirst { case m if m.name == top => m }.get
+    val connects = getConnects(topModule)
+    clockList.foreach { clock =>
+      val origin = getOrigin(connects, clock).serialize.replace('.', '$')
+      if(!sourceList.contains(origin)){
+        outputBuffer.append(s"Bad Origin of $clock is $origin\n")
+      } else {
+        outputBuffer.append(s"Good Origin of $clock is $origin\n")
+      }
+    }
+
+    // Write to output file
+    writer.write(outputBuffer.toString)
+
+    // Return unchanged circuit
+    c
+  }
+}
+
+object RemoveAllButClocks extends Pass {
+  def name = this.getClass.getSimpleName
+  def onStmt(s: Statement): Statement = (s map onStmt) match {
+    case DefWire(i, n, ClockType) => s
+    case DefNode(i, n, value) if value.tpe == ClockType => s
+    case Connect(i, l, r) if l.tpe == ClockType => s
+    case sx: WDefInstance => sx
+    case sx: DefInstance => sx
+    case sx: Block => sx
+    case sx: Conditionally => sx
+    case _ => EmptyStmt
+  }
+  def onModule(m: DefModule): DefModule = m match {
+    case Module(i, n, ps, b) => Module(i, n, ps.filter(_.tpe == ClockType), squashEmpty(onStmt(b)))
+    case ExtModule(i, n, ps, dn, p) => ExtModule(i, n, ps.filter(_.tpe == ClockType), dn, p)
+  }
+  def run(c: Circuit): Circuit = c.copy(modules = c.modules map onModule)
+}

--- a/src/main/scala/firrtl/passes/clocklist/ClockList.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockList.scala
@@ -45,7 +45,7 @@ class ClockList(top: String, writer: Writer) extends Pass {
     val modulesToInline = (c.modules.collect { case Module(_, n, _, _) if n != top => ModuleName(n, CircuitName(c.main)) }).toSet
     val inlineTransform = new InlineInstances
     val inlinedCircuit = inlineTransform.run(onlyClockCircuit, modulesToInline, Set()).circuit
-    val topModule = inlinedCircuit.modules.collectFirst { case m if m.name == top => m }.get
+    val topModule = inlinedCircuit.modules.find(_.name == top).getOrElse(throwInternalError)
 
     // Build a hashmap of connections to use for getOrigins
     val connects = getConnects(topModule)

--- a/src/main/scala/firrtl/passes/clocklist/ClockList.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockList.scala
@@ -1,3 +1,5 @@
+// See license file for details
+
 package firrtl.passes
 package clocklist
 
@@ -13,111 +15,6 @@ import Utils._
 import memlib.AnalysisUtils._
 import memlib._
 import Mappers._
-
-
-class ClockListTransform extends Transform {
-  def inputForm = LowForm
-  def outputForm = LowForm
-  def passSeq(top: String, writer: Writer): Seq[Pass] =
-    Seq(new ClockList(top, writer))
-  def execute(state: CircuitState): CircuitState = getMyAnnotations(state) match {
-    case Some(p) => (p.toSeq.collect { case (ModuleName(m, CircuitName(state.circuit.main)), cla) =>
-      cla match {
-        case x: ClockListAnnotation => (m, x.outputConfig)
-        case _ => error(s"Found an unexpected annotation: $cla")
-      }
-    }) match {
-      case Seq((top, out)) => 
-        val outputFile = new PrintWriter(out)
-        val newC = (new ClockList(top, outputFile)).run(state.circuit)
-        outputFile.close()
-        CircuitState(newC, state.form)
-      case _ => error(s"Found too many (or too few) ClockListAnnotations!")
-    }
-    case None => CircuitState(state.circuit, state.form)
-  }
-}
-
-case class ClockListAnnotation(t: String)
-    extends Annotation with Loose with Unstable {
-  def transform = classOf[ClockListTransform]
-  val usage = """
-[Optional] ClockList
-  List which signal drives each clock of every descendent of specified module
-
-Usage: 
-  --list-clocks -c:<circuit>:-m:<module>:-o:<filename>
-  *** Note: sub-arguments to --list-clocks should be delimited by : and not white space!
-"""    
-
-  //Parse pass options
-  val passOptions = PassConfigUtil.getPassOptions(t, usage)
-  val outputConfig = passOptions.getOrElse(
-    OutputConfigFileName, 
-    error("No output config file provided for ClockList!" + usage)
-  )
-  val passCircuit = passOptions.getOrElse(
-    PassCircuitName, 
-    error("No circuit name specified for ClockList!" + usage)
-  )
-  val passModule = passOptions.getOrElse(
-    PassModuleName, 
-    error("No module name specified for ClockList!" + usage)
-  )
-  passOptions.get(InputConfigFileName) match {
-    case Some(x) => error("Unneeded input config file name!" + usage)
-    case None =>
-  }
-  val target = ModuleName(passModule, CircuitName(passCircuit))
-  def duplicate(n: Named) = n match {
-    case ModuleName(m, CircuitName(c)) => this copy (t = t.replace(s"-c:$passCircuit", s"-c:$c").replace(s"-m:$passModule", s"-m:$m"))
-    case _ => error("Cannot move ClockListAnnotation to a non-module")
-  }
-}
-
-object ClockListUtils {
-  /** Returns a list of clock outputs from instances of external modules
-   */
-  def getSourceList(moduleMap: Map[String, DefModule])(lin: Lineage): Seq[String] = {
-    val s = lin.foldLeft(Seq[String]()){case (sL, (i, l)) =>
-      val sLx = getSourceList(moduleMap)(l)
-      val sLxx = sLx map (i + "$" + _)
-      sL ++ sLxx
-    }
-    val sourceList = moduleMap(lin.name) match {
-      case ExtModule(i, n, ports, dn, p) =>
-        val portExps = ports.flatMap{p => create_exps(WRef(p.name, p.tpe, PortKind, to_gender(p.direction)))}
-        portExps.filter(e => (e.tpe == ClockType) && (gender(e) == FEMALE)).map(e => e.serialize)
-      case _ => Nil
-    }
-    val sx = sourceList ++ s
-    sx
-  }
-  /** Returns a map from instance name to its clock origin.
-   *  Child instances are not included if they share the same clock as their parent
-   */
-  def getOrigins(connects: Connects, me: String, moduleMap: Map[String, DefModule])(lin: Lineage): Map[String, String] = {
-    val sep = if(me == "") "" else "$"
-    // Get origins from all children
-    val childrenOrigins = lin.foldLeft(Map[String, String]()){case (o, (i, l)) =>
-      o ++ getOrigins(connects, me + sep + i, moduleMap)(l)
-    }
-    // If I have a clock, get it
-    val clockOpt = moduleMap(lin.name) match {
-      case Module(i, n, ports, b) => ports.collectFirst { case p if p.name == "clock" => me + sep + "clock" }
-      case ExtModule(i, n, ports, dn, p) => None
-    }
-    // Return new origins with children removed, if they match my clock
-    clockOpt match {
-      case Some(clock) =>
-        val myOrigin = getOrigin(connects, clock).serialize
-        childrenOrigins.foldLeft(Map(me -> myOrigin)) { case (o, (childInstance, childOrigin)) =>
-          if(childOrigin == myOrigin) o else o + (childInstance -> childOrigin)
-        }
-      case None => childrenOrigins
-    }
-  }
-}
 
 /** Starting with a top module, determine the clock origins of each child instance.
  *  Write the result to writer.
@@ -172,27 +69,4 @@ class ClockList(top: String, writer: Writer) extends Pass {
     // Return unchanged circuit
     c
   }
-}
-
-
-/** Remove all statements and ports (except instances/whens/blocks) whose
- *  expressions do not relate to ground types.
- */
-object RemoveAllButClocks extends Pass {
-  def name = this.getClass.getSimpleName
-  def onStmt(s: Statement): Statement = (s map onStmt) match {
-    case DefWire(i, n, ClockType) => s
-    case DefNode(i, n, value) if value.tpe == ClockType => s
-    case Connect(i, l, r) if l.tpe == ClockType => s
-    case sx: WDefInstance => sx
-    case sx: DefInstance => sx
-    case sx: Block => sx
-    case sx: Conditionally => sx
-    case _ => EmptyStmt
-  }
-  def onModule(m: DefModule): DefModule = m match {
-    case Module(i, n, ps, b) => Module(i, n, ps.filter(_.tpe == ClockType), squashEmpty(onStmt(b)))
-    case ExtModule(i, n, ps, dn, p) => ExtModule(i, n, ps.filter(_.tpe == ClockType), dn, p)
-  }
-  def run(c: Circuit): Circuit = c.copy(modules = c.modules map onModule)
 }

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -65,16 +65,12 @@ class ClockListTransform extends Transform {
   def passSeq(top: String, writer: Writer): Seq[Pass] =
     Seq(new ClockList(top, writer))
   def execute(state: CircuitState): CircuitState = getMyAnnotations(state) match {
-    case Some(p) => 
-      val matchingAnnos = p.toSeq.collect { case (ModuleName(m, CircuitName(state.circuit.main)), ClockListAnnotation(_, out)) => (m, out) }
-      matchingAnnos match {
-        case Seq((top, out)) =>  // There should only be one ClockListAnnotations
-          val outputFile = new PrintWriter(out)
-          val newC = (new ClockList(top, outputFile)).run(state.circuit)
-          outputFile.close()
-          CircuitState(newC, state.form)
-        case _ => error(s"Found too many (or too few) ClockListAnnotations!")
-      }
-    case None => CircuitState(state.circuit, state.form)
+    case Seq(ClockListAnnotation(ModuleName(top, CircuitName(state.circuit.main)), out)) => 
+      val outputFile = new PrintWriter(out)
+      val newC = (new ClockList(top, outputFile)).run(state.circuit)
+      outputFile.close()
+      CircuitState(newC, state.form)
+    case Nil => CircuitState(state.circuit, state.form)
+    case seq => error(s"Found illegal clock list annotation(s): $seq")
   }
 }

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -1,0 +1,78 @@
+// See license file for details
+
+package firrtl.passes
+package clocklist
+
+import firrtl._
+import firrtl.ir._
+import Annotations._
+import Utils.error
+import java.io.{File, CharArrayWriter, PrintWriter, Writer}
+import wiring.WiringUtils.{getChildrenMap, countInstances, ChildrenMap, getLineage}
+import wiring.Lineage
+import ClockListUtils._
+import Utils._
+import memlib.AnalysisUtils._
+import memlib._
+import Mappers._
+
+
+case class ClockListAnnotation(t: String)
+    extends Annotation with Loose with Unstable {
+  def transform = classOf[ClockListTransform]
+  val usage = """
+[Optional] ClockList
+  List which signal drives each clock of every descendent of specified module
+
+Usage: 
+  --list-clocks -c:<circuit>:-m:<module>:-o:<filename>
+  *** Note: sub-arguments to --list-clocks should be delimited by : and not white space!
+"""    
+
+  //Parse pass options
+  val passOptions = PassConfigUtil.getPassOptions(t, usage)
+  val outputConfig = passOptions.getOrElse(
+    OutputConfigFileName, 
+    error("No output config file provided for ClockList!" + usage)
+  )
+  val passCircuit = passOptions.getOrElse(
+    PassCircuitName, 
+    error("No circuit name specified for ClockList!" + usage)
+  )
+  val passModule = passOptions.getOrElse(
+    PassModuleName, 
+    error("No module name specified for ClockList!" + usage)
+  )
+  passOptions.get(InputConfigFileName) match {
+    case Some(x) => error("Unneeded input config file name!" + usage)
+    case None =>
+  }
+  val target = ModuleName(passModule, CircuitName(passCircuit))
+  def duplicate(n: Named) = n match {
+    case ModuleName(m, CircuitName(c)) => this copy (t = t.replace(s"-c:$passCircuit", s"-c:$c").replace(s"-m:$passModule", s"-m:$m"))
+    case _ => error("Cannot move ClockListAnnotation to a non-module")
+  }
+}
+
+class ClockListTransform extends Transform {
+  def inputForm = LowForm
+  def outputForm = LowForm
+  def passSeq(top: String, writer: Writer): Seq[Pass] =
+    Seq(new ClockList(top, writer))
+  def execute(state: CircuitState): CircuitState = getMyAnnotations(state) match {
+    case Some(p) => (p.toSeq.collect { case (ModuleName(m, CircuitName(state.circuit.main)), cla) =>
+      cla match {
+        case x: ClockListAnnotation => (m, x.outputConfig)
+        case _ => error(s"Found an unexpected annotation: $cla")
+      }
+    }) match {
+      case Seq((top, out)) => 
+        val outputFile = new PrintWriter(out)
+        val newC = (new ClockList(top, outputFile)).run(state.circuit)
+        outputFile.close()
+        CircuitState(newC, state.form)
+      case _ => error(s"Found too many (or too few) ClockListAnnotations!")
+    }
+    case None => CircuitState(state.circuit, state.form)
+  }
+}

--- a/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListTransform.scala
@@ -16,11 +16,18 @@ import memlib.AnalysisUtils._
 import memlib._
 import Mappers._
 
-
-case class ClockListAnnotation(t: String)
+case class ClockListAnnotation(target: ModuleName, outputConfig: String)
     extends Annotation with Loose with Unstable {
   def transform = classOf[ClockListTransform]
-  val usage = """
+  def duplicate(n: Named) = n match {
+    case m: ModuleName => this.copy(target = m, outputConfig = outputConfig)
+    case _ => error("Clocklist can only annotate a module.")
+  }
+}
+
+object ClockListAnnotation {
+  def apply(t: String) = {
+    val usage = """
 [Optional] ClockList
   List which signal drives each clock of every descendent of specified module
 
@@ -28,29 +35,27 @@ Usage:
   --list-clocks -c:<circuit>:-m:<module>:-o:<filename>
   *** Note: sub-arguments to --list-clocks should be delimited by : and not white space!
 """    
-
-  //Parse pass options
-  val passOptions = PassConfigUtil.getPassOptions(t, usage)
-  val outputConfig = passOptions.getOrElse(
-    OutputConfigFileName, 
-    error("No output config file provided for ClockList!" + usage)
-  )
-  val passCircuit = passOptions.getOrElse(
-    PassCircuitName, 
-    error("No circuit name specified for ClockList!" + usage)
-  )
-  val passModule = passOptions.getOrElse(
-    PassModuleName, 
-    error("No module name specified for ClockList!" + usage)
-  )
-  passOptions.get(InputConfigFileName) match {
-    case Some(x) => error("Unneeded input config file name!" + usage)
-    case None =>
-  }
-  val target = ModuleName(passModule, CircuitName(passCircuit))
-  def duplicate(n: Named) = n match {
-    case ModuleName(m, CircuitName(c)) => this copy (t = t.replace(s"-c:$passCircuit", s"-c:$c").replace(s"-m:$passModule", s"-m:$m"))
-    case _ => error("Cannot move ClockListAnnotation to a non-module")
+  
+    //Parse pass options
+    val passOptions = PassConfigUtil.getPassOptions(t, usage)
+    val outputConfig = passOptions.getOrElse(
+      OutputConfigFileName, 
+      error("No output config file provided for ClockList!" + usage)
+    )
+    val passCircuit = passOptions.getOrElse(
+      PassCircuitName, 
+      error("No circuit name specified for ClockList!" + usage)
+    )
+    val passModule = passOptions.getOrElse(
+      PassModuleName, 
+      error("No module name specified for ClockList!" + usage)
+    )
+    passOptions.get(InputConfigFileName) match {
+      case Some(x) => error("Unneeded input config file name!" + usage)
+      case None =>
+    }
+    val target = ModuleName(passModule, CircuitName(passCircuit))
+    new ClockListAnnotation(target, outputConfig)
   }
 }
 
@@ -60,19 +65,16 @@ class ClockListTransform extends Transform {
   def passSeq(top: String, writer: Writer): Seq[Pass] =
     Seq(new ClockList(top, writer))
   def execute(state: CircuitState): CircuitState = getMyAnnotations(state) match {
-    case Some(p) => (p.toSeq.collect { case (ModuleName(m, CircuitName(state.circuit.main)), cla) =>
-      cla match {
-        case x: ClockListAnnotation => (m, x.outputConfig)
-        case _ => error(s"Found an unexpected annotation: $cla")
+    case Some(p) => 
+      val matchingAnnos = p.toSeq.collect { case (ModuleName(m, CircuitName(state.circuit.main)), ClockListAnnotation(_, out)) => (m, out) }
+      matchingAnnos match {
+        case Seq((top, out)) =>  // There should only be one ClockListAnnotations
+          val outputFile = new PrintWriter(out)
+          val newC = (new ClockList(top, outputFile)).run(state.circuit)
+          outputFile.close()
+          CircuitState(newC, state.form)
+        case _ => error(s"Found too many (or too few) ClockListAnnotations!")
       }
-    }) match {
-      case Seq((top, out)) => 
-        val outputFile = new PrintWriter(out)
-        val newC = (new ClockList(top, outputFile)).run(state.circuit)
-        outputFile.close()
-        CircuitState(newC, state.form)
-      case _ => error(s"Found too many (or too few) ClockListAnnotations!")
-    }
     case None => CircuitState(state.circuit, state.form)
   }
 }

--- a/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
@@ -1,0 +1,62 @@
+// See license file for details
+
+package firrtl.passes
+package clocklist
+
+import firrtl._
+import firrtl.ir._
+import Annotations._
+import Utils.error
+import java.io.{File, CharArrayWriter, PrintWriter, Writer}
+import wiring.WiringUtils.{getChildrenMap, countInstances, ChildrenMap, getLineage}
+import wiring.Lineage
+import ClockListUtils._
+import Utils._
+import memlib.AnalysisUtils._
+import memlib._
+import Mappers._
+
+object ClockListUtils {
+  /** Returns a list of clock outputs from instances of external modules
+   */
+  def getSourceList(moduleMap: Map[String, DefModule])(lin: Lineage): Seq[String] = {
+    val s = lin.foldLeft(Seq[String]()){case (sL, (i, l)) =>
+      val sLx = getSourceList(moduleMap)(l)
+      val sLxx = sLx map (i + "$" + _)
+      sL ++ sLxx
+    }
+    val sourceList = moduleMap(lin.name) match {
+      case ExtModule(i, n, ports, dn, p) =>
+        val portExps = ports.flatMap{p => create_exps(WRef(p.name, p.tpe, PortKind, to_gender(p.direction)))}
+        portExps.filter(e => (e.tpe == ClockType) && (gender(e) == FEMALE)).map(e => e.serialize)
+      case _ => Nil
+    }
+    val sx = sourceList ++ s
+    sx
+  }
+  /** Returns a map from instance name to its clock origin.
+   *  Child instances are not included if they share the same clock as their parent
+   */
+  def getOrigins(connects: Connects, me: String, moduleMap: Map[String, DefModule])(lin: Lineage): Map[String, String] = {
+    val sep = if(me == "") "" else "$"
+    // Get origins from all children
+    val childrenOrigins = lin.foldLeft(Map[String, String]()){case (o, (i, l)) =>
+      o ++ getOrigins(connects, me + sep + i, moduleMap)(l)
+    }
+    // If I have a clock, get it
+    val clockOpt = moduleMap(lin.name) match {
+      case Module(i, n, ports, b) => ports.collectFirst { case p if p.name == "clock" => me + sep + "clock" }
+      case ExtModule(i, n, ports, dn, p) => None
+    }
+    // Return new origins with children removed, if they match my clock
+    clockOpt match {
+      case Some(clock) =>
+        val myOrigin = getOrigin(connects, clock).serialize
+        childrenOrigins.foldLeft(Map(me -> myOrigin)) { case (o, (childInstance, childOrigin)) =>
+          if(childOrigin == myOrigin) o else o + (childInstance -> childOrigin)
+        }
+      case None => childrenOrigins
+    }
+  }
+}
+

--- a/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
+++ b/src/main/scala/firrtl/passes/clocklist/ClockListUtils.scala
@@ -28,7 +28,7 @@ object ClockListUtils {
     val sourceList = moduleMap(lin.name) match {
       case ExtModule(i, n, ports, dn, p) =>
         val portExps = ports.flatMap{p => create_exps(WRef(p.name, p.tpe, PortKind, to_gender(p.direction)))}
-        portExps.filter(e => (e.tpe == ClockType) && (gender(e) == FEMALE)).map(e => e.serialize)
+        portExps.filter(e => (e.tpe == ClockType) && (gender(e) == FEMALE)).map(_.serialize)
       case _ => Nil
     }
     val sx = sourceList ++ s

--- a/src/main/scala/firrtl/passes/clocklist/RemoveAllButClocks.scala
+++ b/src/main/scala/firrtl/passes/clocklist/RemoveAllButClocks.scala
@@ -1,0 +1,39 @@
+// See license file for details
+
+package firrtl.passes
+package clocklist
+
+import firrtl._
+import firrtl.ir._
+import Annotations._
+import Utils.error
+import java.io.{File, CharArrayWriter, PrintWriter, Writer}
+import wiring.WiringUtils.{getChildrenMap, countInstances, ChildrenMap, getLineage}
+import wiring.Lineage
+import ClockListUtils._
+import Utils._
+import memlib.AnalysisUtils._
+import memlib._
+import Mappers._
+
+/** Remove all statements and ports (except instances/whens/blocks) whose
+ *  expressions do not relate to ground types.
+ */
+object RemoveAllButClocks extends Pass {
+  def name = this.getClass.getSimpleName
+  def onStmt(s: Statement): Statement = (s map onStmt) match {
+    case DefWire(i, n, ClockType) => s
+    case DefNode(i, n, value) if value.tpe == ClockType => s
+    case Connect(i, l, r) if l.tpe == ClockType => s
+    case sx: WDefInstance => sx
+    case sx: DefInstance => sx
+    case sx: Block => sx
+    case sx: Conditionally => sx
+    case _ => EmptyStmt
+  }
+  def onModule(m: DefModule): DefModule = m match {
+    case Module(i, n, ps, b) => Module(i, n, ps.filter(_.tpe == ClockType), squashEmpty(onStmt(b)))
+    case ExtModule(i, n, ps, dn, p) => ExtModule(i, n, ps.filter(_.tpe == ClockType), dn, p)
+  }
+  def run(c: Circuit): Circuit = c.copy(modules = c.modules map onModule)
+}

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -15,6 +15,7 @@ sealed trait PassOption
 case object InputConfigFileName extends PassOption
 case object OutputConfigFileName extends PassOption
 case object PassCircuitName extends PassOption
+case object PassModuleName extends PassOption
 
 object PassConfigUtil {
   type PassOptionMap = Map[PassOption, String]
@@ -32,6 +33,8 @@ object PassConfigUtil {
           nextPassOption(map + (OutputConfigFileName -> value), tail)
         case "-c" :: value :: tail =>
           nextPassOption(map + (PassCircuitName -> value), tail)
+        case "-m" :: value :: tail =>
+          nextPassOption(map + (PassModuleName -> value), tail)
         case option :: tail =>
           error("Unknown option " + option + usage)
       }

--- a/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
@@ -41,6 +41,9 @@ case class Lineage(
     |$tab children: ${children.map(c => tab + "   " + c._2.shortSerialize(tab + "    "))}
     |""".stripMargin
 
+  def foldLeft[B](z: B)(op: (B, (String, Lineage)) => B): B = 
+    this.children.foldLeft(z)(op)
+
   def serialize(tab: String): String = s"""
     |$tab name: $name,
     |$tab source: $source,

--- a/src/test/scala/firrtlTests/ClockListTests.scala
+++ b/src/test/scala/firrtlTests/ClockListTests.scala
@@ -1,0 +1,90 @@
+package firrtlTests
+
+import java.io._
+import org.scalatest._
+import org.scalatest.prop._
+import firrtl._
+import firrtl.ir.Circuit
+import firrtl.passes._
+import firrtl.Parser.IgnoreInfo
+import Annotations._
+import clocklist._
+
+class ClockListTests extends FirrtlFlatSpec {
+  def parse (input:String) = Parser.parse(input.split("\n").toIterator, IgnoreInfo)
+  private def executeTest(input: String, expected: Seq[String], passes: Seq[Pass]) = {
+    val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
+      (c: Circuit, p: Pass) => p.run(c)
+    }
+    val lines = c.serialize.split("\n") map normalized
+
+    expected foreach { e =>
+      lines should contain(e)
+    }
+  }
+
+  def passes = Seq(
+    ToWorkingIR,
+    ResolveKinds,
+    InferTypes,
+    ResolveGenders,
+    InferWidths
+  )
+
+  "Getting clock list" should "work" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input clock: Clock
+        |    inst ht of HTop
+        |    ht.clock <= clock
+        |  module HTop :
+        |    input clock: Clock
+        |    inst h of Hurricane
+        |    h.clkTop <= clock
+        |    h.clock <= h.clk1
+        |  module Hurricane :
+        |    input clock: Clock
+        |    input clkTop: Clock
+        |    output clk1: Clock
+        |    inst b of B
+        |    inst c of C
+        |    inst clkGen of ClockGen
+        |    clkGen.clkTop <= clkTop
+        |    clk1 <= clkGen.clk1
+        |    b.clock <= clkGen.clk2
+        |    c.clock <= clkGen.clk3
+        |  module B :
+        |    input clock: Clock
+        |    reg r: UInt<5>, clock
+        |    inst d of D
+        |    d.clock <= clock
+        |  module C :
+        |    input clock: Clock
+        |    reg r: UInt<5>, clock
+        |  module D :
+        |    input clock: Clock
+        |    reg r: UInt<5>, clock
+        |  extmodule ClockGen :
+        |    input clkTop: Clock
+        |    output clk1: Clock
+        |    output clk2: Clock
+        |    output clk3: Clock
+        |""".stripMargin
+    val check = 
+  """Clocklist: List(h$b$d$clock, h$b$clock, h$c$clock, h$clock, clock) 
+    |Sourcelist: List(h$clkGen$clk1, h$clkGen$clk2, h$clkGen$clk3, clock) 
+    |Good Origin of h$b$d$clock is h$clkGen$clk2
+    |Good Origin of h$b$clock is h$clkGen$clk2
+    |Good Origin of h$c$clock is h$clkGen$clk3
+    |Good Origin of h$clock is h$clkGen$clk1
+    |Good Origin of clock is clock
+    |""".stripMargin
+    val c = passes.foldLeft(parse(input)) {
+      (c: Circuit, p: Pass) => p.run(c)
+    }
+    val writer = new StringWriter()
+    val retC = new ClockList("HTop", writer).run(c)
+    (writer.toString()) should be (check)
+  }
+}

--- a/src/test/scala/firrtlTests/ClockListTests.scala
+++ b/src/test/scala/firrtlTests/ClockListTests.scala
@@ -83,7 +83,6 @@ class ClockListTests extends FirrtlFlatSpec {
     }
     val writer = new StringWriter()
     val retC = new ClockList("HTop", writer).run(c)
-    println(writer.toString())
     (writer.toString()) should be (check)
   }
 }

--- a/src/test/scala/firrtlTests/ClockListTests.scala
+++ b/src/test/scala/firrtlTests/ClockListTests.scala
@@ -72,19 +72,18 @@ class ClockListTests extends FirrtlFlatSpec {
         |    output clk3: Clock
         |""".stripMargin
     val check = 
-  """Clocklist: List(h$b$d$clock, h$b$clock, h$c$clock, h$clock, clock) 
-    |Sourcelist: List(h$clkGen$clk1, h$clkGen$clk2, h$clkGen$clk3, clock) 
-    |Good Origin of h$b$d$clock is h$clkGen$clk2
-    |Good Origin of h$b$clock is h$clkGen$clk2
-    |Good Origin of h$c$clock is h$clkGen$clk3
-    |Good Origin of h$clock is h$clkGen$clk1
+  """Sourcelist: List(h$clkGen$clk1, h$clkGen$clk2, h$clkGen$clk3, clock) 
     |Good Origin of clock is clock
+    |Good Origin of h.clock is h$clkGen.clk1
+    |Good Origin of h$b.clock is h$clkGen.clk2
+    |Good Origin of h$c.clock is h$clkGen.clk3
     |""".stripMargin
     val c = passes.foldLeft(parse(input)) {
       (c: Circuit, p: Pass) => p.run(c)
     }
     val writer = new StringWriter()
     val retC = new ClockList("HTop", writer).run(c)
+    println(writer.toString())
     (writer.toString()) should be (check)
   }
 }

--- a/src/test/scala/firrtlTests/ClockListTests.scala
+++ b/src/test/scala/firrtlTests/ClockListTests.scala
@@ -11,7 +11,6 @@ import Annotations._
 import clocklist._
 
 class ClockListTests extends FirrtlFlatSpec {
-  def parse (input:String) = Parser.parse(input.split("\n").toIterator, IgnoreInfo)
   private def executeTest(input: String, expected: Seq[String], passes: Seq[Pass]) = {
     val c = passes.foldLeft(Parser.parse(input.split("\n").toIterator)) {
       (c: Circuit, p: Pass) => p.run(c)


### PR DESCRIPTION
Given a "top" module in the design, list the driving clock signal for all `input clock: Clock` ports in every child module. Valid sources are also listed, including the top "clock" signal, as well as output clock-typed ports from external modules.