### PR TITLE
Bugfix inferwidth

### DIFF
--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -600,6 +600,12 @@ object CheckWidths extends Pass {
       w
     }
 
+    def hasWidth(tpe: Type): Boolean = tpe match {
+      case GroundType(IntWidth(w)) => true
+      case GroundType(_) => false
+      case _ => println(tpe); throwInternalError
+    }
+
     def check_width_t(info: Info, mname: String)(t: Type): Type =
       t map check_width_t(info, mname) map check_width_w(info, mname)
 
@@ -615,13 +621,13 @@ object CheckWidths extends Pass {
             errors append new WidthTooSmall(info, mname, e.value)
           case _ =>
         }
-        case DoPrim(Bits, Seq(a), Seq(hi, lo), _) if bitWidth(a.tpe) <= hi =>
+        case DoPrim(Bits, Seq(a), Seq(hi, lo), _) if (hasWidth(a.tpe) && bitWidth(a.tpe) <= hi) =>
           errors append new BitsWidthException(info, mname, hi, bitWidth(a.tpe))
-        case DoPrim(Head, Seq(a), Seq(n), _) if bitWidth(a.tpe) < n =>
+        case DoPrim(Head, Seq(a), Seq(n), _) if (hasWidth(a.tpe) && bitWidth(a.tpe) < n) =>
           errors append new HeadWidthException(info, mname, n, bitWidth(a.tpe))
-        case DoPrim(Tail, Seq(a), Seq(n), _) if bitWidth(a.tpe) <= n =>
+        case DoPrim(Tail, Seq(a), Seq(n), _) if (hasWidth(a.tpe) && bitWidth(a.tpe) <= n) =>
           errors append new TailWidthException(info, mname, n, bitWidth(a.tpe))
-        case DoPrim(Dshl, Seq(a, b), _, _) if bitWidth(b.tpe) >= BigInt(32) =>
+        case DoPrim(Dshl, Seq(a, b), _, _) if (hasWidth(a.tpe) && bitWidth(b.tpe) >= BigInt(32)) =>
           errors append new WidthTooBig(info, mname)
         case _ =>
       }

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -81,7 +81,7 @@ object InferWidths extends Pass {
 
     def remove_cycle(n: String)(w: Width): Width = {
       //;println-all-debug(["Removing cycle for " n " inside " w])
-      w map remove_cycle(n) match {
+      w match {
         case wx: MaxWidth => MaxWidth(wx.args filter {
           case wxx: VarWidth => !(n equals wxx.name)
           case _ => true

--- a/src/test/scala/firrtlTests/WidthSpec.scala
+++ b/src/test/scala/firrtlTests/WidthSpec.scala
@@ -78,4 +78,27 @@ class WidthSpec extends FirrtlFlatSpec {
       executeTest(input, Nil, passes)
     }
   }
+  "Circular reg depending on reg + 1" should "error" in {
+    val passes = Seq(
+      ToWorkingIR,
+      CheckHighForm,
+      ResolveKinds,
+      InferTypes,
+      CheckTypes,
+      InferWidths,
+      CheckWidths)
+    val input =
+      """circuit Unit :
+        |  module Unit :
+        |    input clock: Clock
+        |    input reset: UInt<1>
+        |    reg r : UInt, clock with :
+        |      reset => (reset, UInt(3))
+        |    node T_7 = add(r, r)
+        |    r <= T_7
+        |""".stripMargin
+    intercept[CheckWidths.UninferredWidth] {
+      executeTest(input, Nil, passes)
+    }
+  }
 }


### PR DESCRIPTION
This will *probably* lead to more uninferred width errors, but now widths
that were previously incorrectly inferred are now correctly uninferred.

An example is:
  reg r : UInt, clock with: (reset => (reset, UInt<2>(3)))
  node x = add(r, r)
  r <= x

Here, r's width follows the following formula, which cannot be solved:

rWidth >= max(max(rWidth, rWidth) + 1, 2)