### PR TITLE
Copy (explicitly) test resource to targetdir.

### DIFF
--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -2,19 +2,14 @@
 
 package firrtlTests
 
-import java.io.File
+import java.io.{File, FileNotFoundException, FileOutputStream}
+import org.scalatest.{FreeSpec, Matchers}
 
-import firrtl.annotations.Annotation
-import org.scalatest.{Matchers, FreeSpec}
-
-import firrtl._
 import firrtl.passes.InlineInstances
-import firrtl.passes.memlib.{ReplSeqMem, InferReadWrite}
-import org.scalatest.{Matchers, FreeSpec}
-
+import firrtl.passes.memlib.{InferReadWrite, ReplSeqMem}
 import firrtl._
 
-class DriverSpec extends FreeSpec with Matchers {
+class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities {
   "CommonOptions are some simple options available across the chisel3 ecosystem" - {
     "CommonOption provide an scopt implementation of an OptionParser" - {
       "Options can be set from an Array[String] as is passed into a main" - {
@@ -133,9 +128,11 @@ class DriverSpec extends FreeSpec with Matchers {
     val optionsManager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
       commonOptions = commonOptions.copy(topName = "a.fir")
       firrtlOptions = firrtlOptions.copy(
-        annotationFileNameOverride = "src/test/resources/annotations/SampleAnnotations"
+        annotationFileNameOverride = "SampleAnnotations"
       )
     }
+    val annotationsTestFile =  new File(optionsManager.commonOptions.targetDirName, optionsManager.firrtlOptions.annotationFileNameOverride + ".anno")
+    copyResourceToFile("/annotations/SampleAnnotations.anno", annotationsTestFile)
     optionsManager.firrtlOptions.annotations.length should be (0)
     Driver.loadAnnotations(optionsManager)
     optionsManager.firrtlOptions.annotations.length should be (9)


### PR DESCRIPTION
If we execute tests somewhere other than the root of the firrtl project directory (in a parent project directory for example), the resource file may not be where we expect it.
Also clean up imports.