### PR TITLE
Delete sample annotations file at the end of test

### DIFF
--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -138,6 +138,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     optionsManager.firrtlOptions.annotations.length should be (9)
 
     optionsManager.firrtlOptions.annotations.head.transformClass should be ("firrtl.passes.InlineInstances")
+    annotationsTestFile.delete()
   }
 
   val input =


### PR DESCRIPTION
Minor change cleans up a sample file at the end of the test case.