### PR TITLE
Speed up deduplication. Fixes #391

### DIFF
--- a/src/test/scala/firrtlTests/transforms/DedupTests.scala
+++ b/src/test/scala/firrtlTests/transforms/DedupTests.scala
@@ -116,10 +116,10 @@ class DedupModuleTests extends HighTransformSpec {
            |  module Top :
            |    inst a1 of A
            |    inst a2 of A
-           |  module A : @[yy 2:2 xx 1:1]
-           |    output x: UInt<1> @[yy 2:2 xx 1:1]
-           |    inst b of B @[yy 2:2 xx 1:1]
-           |    x <= b.x @[yy 2:2 xx 1:1]
+           |  module A : @[yy 2:2]
+           |    output x: UInt<1> @[yy 2:2]
+           |    inst b of B @[yy 2:2]
+           |    x <= b.x @[yy 2:2]
            |  module B :
            |    output x: UInt<1>
            |    x <= UInt(1)


### PR DESCRIPTION
Removes combining of source locators since the benefit is dubious.
Adds MultiInfo for faster appending of source locators in future.

I ended up removing the combining of source locators even though I had fixed the performance pathology because it's not clear to me if it's even beneficial. I looked at the results of deduplicating 64 identical Queues and all of the concatinations made the results... not pretty. Anyway we can always add it back in a sensible way in the future if we want to.