### PR TITLE
Rework Attach to work on arbitrary Analog hierarchies

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -108,7 +108,7 @@ stmt
   | 'stop(' exp exp IntLit ')' info?
   | 'printf(' exp exp StringLit ( exp)* ')' info?
   | 'skip' info?
-  | 'attach' exp 'to' '(' exp* ')' info?
+  | 'attach' '(' exp+ ')' info?
   ;
 
 memField

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -268,7 +268,7 @@ class Visitor(infoMode: InfoMode) extends FIRRTLBaseVisitor[FirrtlNode] {
         case "node" => DefNode(info, ctx.id(0).getText, visitExp(ctx.exp(0)))
 
         case "stop(" => Stop(info, string2Int(ctx.IntLit().getText), visitExp(ctx.exp(0)), visitExp(ctx.exp(1)))
-        case "attach" => Attach(info, visitExp(ctx.exp.head), ctx.exp.tail map visitExp)
+        case "attach" => Attach(info, ctx.exp map visitExp)
         case "printf(" => Print(info, visitStringLit(ctx.StringLit), ctx.exp.drop(2).map(visitExp),
           visitExp(ctx.exp(0)), visitExp(ctx.exp(1)))
         case "skip" => EmptyStmt

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -30,6 +30,12 @@ case class WRef(name: String, tpe: Type, kind: Kind, gender: Gender) extends Exp
   def mapType(f: Type => Type): Expression = this.copy(tpe = f(tpe))
   def mapWidth(f: Width => Width): Expression = this
 }
+object WRef {
+  /** Creates a WRef from a Wire */
+  def apply(wire: DefWire): WRef = new WRef(wire.name, wire.tpe, WireKind, UNKNOWNGENDER)
+  /** Creates a WRef from a Register */
+  def apply(reg: DefRegister): WRef = new WRef(reg.name, reg.tpe, RegKind, UNKNOWNGENDER)
+}
 case class WSubField(exp: Expression, name: String, tpe: Type, gender: Gender) extends Expression {
   def serialize: String = s"${exp.serialize}.$name"
   def mapExpr(f: Expression => Expression): Expression = this.copy(exp = f(exp))

--- a/src/main/scala/firrtl/WIR.scala
+++ b/src/main/scala/firrtl/WIR.scala
@@ -83,14 +83,20 @@ case class WDefInstance(info: Info, name: String, module: String, tpe: Type) ext
   def mapType(f: Type => Type): Statement = this.copy(tpe = f(tpe))
   def mapString(f: String => String): Statement = this.copy(name = f(name))
 }
-case class WDefInstanceConnector(info: Info, name: String, module: String, tpe: Type, exprs: Seq[Expression]) extends Statement with IsDeclaration {
-  def serialize: String = s"inst $name of $module with ${tpe.serialize} connected to (" + exprs.map(_.serialize).mkString(", ") + ")" + info.serialize
-  def mapExpr(f: Expression => Expression): Statement = this.copy(exprs = exprs map f)
+case class WDefInstanceConnector(
+    info: Info,
+    name: String,
+    module: String,
+    tpe: Type,
+    portCons: Seq[(Expression, Expression)]) extends Statement with IsDeclaration {
+  def serialize: String = s"inst $name of $module with ${tpe.serialize} connected to " +
+                          portCons.map(_._2.serialize).mkString("(", ", ", ")") + info.serialize
+  def mapExpr(f: Expression => Expression): Statement =
+    this.copy(portCons = portCons map { case (e1, e2) => (f(e1), f(e2)) })
   def mapStmt(f: Statement => Statement): Statement = this
   def mapType(f: Type => Type): Statement = this.copy(tpe = f(tpe))
   def mapString(f: String => String): Statement = this.copy(name = f(name))
 }
-
 
 // Resultant width is the same as the maximum input width
 case object Addw extends PrimOp { override def toString = "addw" }

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -248,10 +248,10 @@ case class IsInvalid(info: Info, expr: Expression) extends Statement with HasInf
   def mapType(f: Type => Type): Statement = this
   def mapString(f: String => String): Statement = this
 }
-case class Attach(info: Info, source: Expression, exprs: Seq[Expression]) extends Statement with HasInfo {
-  def serialize: String = "attach " + source.serialize + " to (" + exprs.map(_.serialize).mkString(", ") + ")"
+case class Attach(info: Info, exprs: Seq[Expression]) extends Statement with HasInfo {
+  def serialize: String = "attach " + exprs.map(_.serialize).mkString("(", ", ", ")")
   def mapStmt(f: Statement => Statement): Statement = this
-  def mapExpr(f: Expression => Expression): Statement = Attach(info, f(source), exprs map f)
+  def mapExpr(f: Expression => Expression): Statement = Attach(info, exprs map f)
   def mapType(f: Type => Type): Statement = this
   def mapString(f: String => String): Statement = this
 }

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -87,10 +87,10 @@ object CheckWidths extends Pass {
     def check_width_s(minfo: Info, mname: String)(s: Statement): Statement = {
       val info = get_info(s) match { case NoInfo => minfo case x => x }
       s map check_width_e(info, mname) map check_width_s(info, mname) map check_width_t(info, mname) match {
-        case Attach(infox, source, exprs) =>
-          exprs foreach ( e =>
-            if (bitWidth(e.tpe) != bitWidth(source.tpe))
-              errors append new AttachWidthsNotEqual(infox, mname, e.serialize, source.serialize)
+        case Attach(infox, exprs) =>
+          exprs.tail.foreach ( e =>
+            if (bitWidth(e.tpe) != bitWidth(exprs.head.tpe))
+              errors.append(new AttachWidthsNotEqual(infox, mname, e.serialize, exprs.head.serialize))
           )
           s
         case _ => s

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -288,8 +288,10 @@ object InferWidths extends Pass {
         case (s:Conditionally) => v ++= 
            get_constraints_t(s.pred.tpe, UIntType(IntWidth(1))) ++
            get_constraints_t(UIntType(IntWidth(1)), s.pred.tpe)
-        case (s: Attach) =>
-          v += WGeq(getWidth(s.source), MaxWidth(s.exprs map (e => getWidth(e.tpe))))
+        case Attach(_, exprs) =>
+          // All widths must be equal
+          val widths = exprs map (e => getWidth(e.tpe))
+          v ++= widths.tail map (WGeq(widths.head, _))
         case _ =>
       }
       s map get_constraints_e map get_constraints_s

--- a/src/test/scala/firrtlTests/AttachSpec.scala
+++ b/src/test/scala/firrtlTests/AttachSpec.scala
@@ -11,7 +11,7 @@ import firrtl.ir.Circuit
 import firrtl.passes._
 import firrtl.Parser.IgnoreInfo
 
-class InoutVerilog extends FirrtlFlatSpec {
+class InoutVerilogSpec extends FirrtlFlatSpec {
   private def executeTest(input: String, expected: Seq[String], compiler: Compiler) = {
     val writer = new StringWriter()
     compiler.compile(CircuitState(parse(input), ChirrtlForm), writer)
@@ -20,123 +20,87 @@ class InoutVerilog extends FirrtlFlatSpec {
       lines should contain(e)
     }
   }
-  "Circuit" should "attach a module input source" in {
-    val compiler = new VerilogCompiler
-    val input =
-      """circuit Attaching : 
-         |  module Attaching : 
-         |    input an: Analog<3>
-         |    inst a of A
-         |    inst b of B
-         |    attach an to (a.an1, b.an2)
-         |  module A: 
-         |    input an1: Analog<3>
-         |  module B:
-         |    input an2: Analog<3> """.stripMargin
-     val check = 
-      """module Attaching(
-        |  inout  [2:0] an
-        |);
-        |  A a (
-        |    .an1(an)
-        |  );
-        |  B b (
-        |    .an2(an)
-        |  );
-        |endmodule
-        |module A(
-        |  inout  [2:0] an1
-        |);
-        |endmodule
-        |module B(
-        |  inout  [2:0] an2
-        |);
-        |endmodule
-        |""".stripMargin.split("\n") map normalized
-     executeTest(input, check, compiler)
-   }
 
-  "Circuit" should "attach a module output source" in {
-    val compiler = new VerilogCompiler
-    val input =
-      """circuit Attaching : 
-         |  module Attaching : 
-         |    output an: Analog<3>
-         |    inst a of A
-         |    inst b of B
-         |    attach an to (a.an1, b.an2)
-         |  module A: 
-         |    input an1: Analog<3>
-         |  module B:
-         |    input an2: Analog<3> """.stripMargin
-     val check = 
-      """module Attaching(
-        |  inout  [2:0] an
-        |);
-        |  A a (
-        |    .an1(an)
-        |  );
-        |  B b (
-        |    .an2(an)
-        |  );
-        |endmodule
-        |module A(
-        |  inout  [2:0] an1
-        |);
-        |endmodule
-        |module B(
-        |  inout  [2:0] an2
-        |);
-        |endmodule
-        |""".stripMargin.split("\n") map normalized
-     executeTest(input, check, compiler)
-   }
+  behavior of "Analog"
 
-  "Circuit" should "not attach an instance input source" in {
+  it should "attach a module input source directly" in {
     val compiler = new VerilogCompiler
     val input =
-      """circuit Attaching : 
-         |  module Attaching : 
-         |    inst a of A
-         |    inst b of B
-         |    attach a.an to (b.an)
-         |  module A: 
-         |    input an: Analog<3>
-         |  module B:
-         |    input an: Analog<3> """.stripMargin
-     intercept[CheckTypes.IllegalAttachSource] {
-       executeTest(input, Seq.empty, compiler)
-     }
-   }
-
-  "Circuit" should "attach an instance output source" in {
-    val compiler = new VerilogCompiler
-    val input =
-      """circuit Attaching : 
-         |  module Attaching : 
-         |    inst a of A
-         |    inst b of B
-         |    attach b.an to (a.an)
-         |  module A: 
-         |    input an: Analog<3>
-         |  module B:
-         |    input an: Analog<3> """.stripMargin
-    intercept[CheckTypes.IllegalAttachSource] {
-      executeTest(input, Seq.empty, compiler)
-    }
+     """circuit Attaching :
+        |  module Attaching :
+        |    input an: Analog<3>
+        |    inst a of A
+        |    inst b of B
+        |    attach (an, a.an1, b.an2)
+        |  module A:
+        |    input an1: Analog<3>
+        |  module B:
+        |    input an2: Analog<3> """.stripMargin
+    val check =
+     """module Attaching(
+       |  inout  [2:0] an
+       |);
+       |  A a (
+       |    .an1(an)
+       |  );
+       |  B b (
+       |    .an2(an)
+       |  );
+       |endmodule
+       |module A(
+       |  inout  [2:0] an1
+       |);
+       |endmodule
+       |module B(
+       |  inout  [2:0] an2
+       |);
+       |endmodule
+       |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
   }
 
-  "Circuit" should "attach a wire source" in {
+  it should "attach two instances" in {
     val compiler = new VerilogCompiler
     val input =
-      """circuit Attaching : 
-         |  module Attaching : 
+     """circuit Attaching :
+        |  module Attaching :
+        |    inst a of A
+        |    inst b of B
+        |    attach (a.an, b.an)
+        |  module A:
+        |    input an: Analog<3>
+        |  module B:
+        |    input an: Analog<3> """.stripMargin
+    val check =
+     """module Attaching(
+       |);
+       |  wire [2:0] _GEN_0;
+       |  A a (
+       |    .an(_GEN_0)
+       |  );
+       |  A b (
+       |    .an(_GEN_0)
+       |  );
+       |endmodule
+       |module A(
+       |  inout  [2:0] an
+       |);
+       |endmodule
+       |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+  }
+
+  it should "attach a wire source" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit Attaching :
+         |  module Attaching :
          |    wire x: Analog
          |    inst a of A
-         |    attach x to (a.an)
-         |  module A: 
+         |    attach (x, a.an)
+         |  module A:
          |    input an: Analog<3> """.stripMargin
-    val check = 
+    val check =
       """module Attaching(
         |);
         |  wire [2:0] x;
@@ -146,6 +110,85 @@ class InoutVerilog extends FirrtlFlatSpec {
         |endmodule
         |""".stripMargin.split("\n") map normalized
     executeTest(input, check, compiler)
+  }
+
+  it should "attach multiple sources" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit Attaching :
+         |  module Attaching :
+         |    input a1 : Analog<3>
+         |    input a2 : Analog<3>
+         |    wire x: Analog<3>
+         |    attach (x, a1, a2)""".stripMargin
+    val check =
+      """module Attaching(
+        |  inout  [2:0] a1,
+        |  inout  [2:0] a2
+        |);
+        |  wire [2:0] x;
+        |  `ifdef SYNTHESIS
+        |    assign x = a1;
+        |    assign a1 = x;
+        |    assign x = a2;
+        |    assign a2 = x;
+        |    assign a1 = a2;
+        |    assign a2 = a1;
+        |  `elseif verilator
+        |    `error "Verilator does not support alias and thus cannot arbirarily connect bidirectional wires and ports"
+        |  `else
+        |    alias x = a1 = a2;
+        |  `endif
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+  }
+
+  it should "preserve attach order" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit Attaching :
+         |  module Attaching :
+         |    input a : Analog<32>
+         |    input b : Analog<32>
+         |    input c : Analog<32>
+         |    input d : Analog<32>
+         |    attach (a, b)
+         |    attach (c, b)
+         |    attach (a, d)""".stripMargin
+    val check =
+      """module Attaching(
+        |  inout  [31:0] a,
+        |  inout  [31:0] b,
+        |  inout  [31:0] c,
+        |  inout  [31:0] d
+        |);
+        |    alias a = b = c = d;
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+
+    val input2 =
+      """circuit Attaching :
+         |  module Attaching :
+         |    input a : Analog<32>
+         |    input b : Analog<32>
+         |    input c : Analog<32>
+         |    input d : Analog<32>
+         |    attach (a, b)
+         |    attach (c, d)
+         |    attach (d, a)""".stripMargin
+    val check2 =
+      """module Attaching(
+        |  inout  [31:0] a,
+        |  inout  [31:0] b,
+        |  inout  [31:0] c,
+        |  inout  [31:0] d
+        |);
+        |    alias a = b = c = d;
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input2, check2, compiler)
   }
 }
 
@@ -211,7 +254,7 @@ class AttachAnalogSpec extends FirrtlFlatSpec {
       """circuit Unit :
         |  module Unit :
         |    input clock: Clock
-        |    mem m: 
+        |    mem m:
         |      data-type => Analog<2>
         |      depth => 4
         |      read-latency => 0
@@ -243,7 +286,7 @@ class AttachAnalogSpec extends FirrtlFlatSpec {
     }
   }
 
-  "Attaching a non-analog source" should "not be ok" in {
+  "Attaching a non-analog expression" should "not be ok" in {
     val passes = Seq(
       ToWorkingIR,
       CheckHighForm,
@@ -256,80 +299,12 @@ class AttachAnalogSpec extends FirrtlFlatSpec {
         |    input source: UInt<2>
         |    inst a of A
         |    inst b of B
-        |    attach source to (a.o, b.o)
+        |    attach (source, a.o, b.o)
         |  extmodule A :
         |    output o: Analog<2>
         |  extmodule B:
         |    input o: Analog<2>""".stripMargin
-    intercept[CheckTypes.IllegalAttachSource] {
-      passes.foldLeft(parse(input)) {
-        (c: Circuit, p: Pass) => p.run(c)
-      }
-    }
-  }
-
-  "Attach instance analog male source" should "not be ok." in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes)
-    val input =
-      """circuit Unit :
-        |  module Unit :
-        |    inst a of A
-        |    inst b of B
-        |    attach a.o to (b.o)
-        |  extmodule A :
-        |    output o: Analog<2>
-        |  extmodule B:
-        |    input o: Analog<2>""".stripMargin
-    intercept[CheckTypes.IllegalAttachSource] {
-      passes.foldLeft(parse(input)) {
-        (c: Circuit, p: Pass) => p.run(c)
-      }
-    }
-  }
-
-  "Attach instance analog female source" should "not be ok." in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes)
-    val input =
-      """circuit Unit :
-        |  module Unit :
-        |    inst a of A
-        |    inst b of B
-        |    attach b.o to (a.o)
-        |  extmodule A :
-        |    output o: Analog<2>
-        |  extmodule B:
-        |    input o: Analog<2>""".stripMargin
-    intercept[CheckTypes.IllegalAttachSource] {
-      passes.foldLeft(parse(input)) {
-        (c: Circuit, p: Pass) => p.run(c)
-      }
-    }
-  }
-
-  "Attach port analog expr" should "throw an exception" in {
-    val passes = Seq(
-      ToWorkingIR,
-      CheckHighForm,
-      ResolveKinds,
-      InferTypes,
-      CheckTypes)
-    val input =
-      """circuit Unit :
-        |  module Unit :
-        |    input i: Analog<2>
-        |    input j: Analog<2>
-        |    attach j to (i) """.stripMargin
-    intercept[CheckTypes.IllegalAttachExp] {
+    intercept[CheckTypes.OpNotAnalog] {
       passes.foldLeft(parse(input)) {
         (c: Circuit, p: Pass) => p.run(c)
       }
@@ -350,7 +325,7 @@ class AttachAnalogSpec extends FirrtlFlatSpec {
         |  module Unit :
         |    input i: Analog<3>
         |    inst a of A
-        |    attach i to (a.o) 
+        |    attach (i, a.o)
         |  extmodule A :
         |    output o: Analog<2> """.stripMargin
     intercept[CheckWidths.AttachWidthsNotEqual] {
@@ -359,28 +334,4 @@ class AttachAnalogSpec extends FirrtlFlatSpec {
       }
     }
   }
-
-  //"Simple compound expressions" should "be split" in {
-  //  val passes = Seq(
-  //    ToWorkingIR,
-  //    ResolveKinds,
-  //    InferTypes,
-  //    ResolveGenders,
-  //    InferWidths,
-  //    SplitExpressions
-  //  )
-  //  val input =
-  //    """circuit Top :
-  //       |  module Top :
-  //       |    input a : UInt<32>
-  //       |    input b : UInt<32>
-  //       |    input d : UInt<32>
-  //       |    output c : UInt<1>
-  //       |    c <= geq(add(a, b),d)""".stripMargin
-  //  val check = Seq(
-  //    "node GEN_0 = add(a, b)",
-  //    "c <= geq(GEN_0, d)"
-  //  )
-  //  executeTest(input, check, passes)
-  //}
 }


### PR DESCRIPTION
Now you can just attach Analogs without any concept of "source". It's just representing an electrical connection.