### PR TITLE
Fix anno in backend

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -229,19 +229,32 @@ object FileUtils {
     *
     * @param directoryPathName a directory hierarchy to delete
     */
-  def deleteDirectoryHierarchy(directoryPathName: String): Unit = {
-    if(directoryPathName.isEmpty || directoryPathName.startsWith("/")) {
-      // don't delete absolute path
+  def deleteDirectoryHierarchy(directoryPathName: String): Boolean = {
+    deleteDirectoryHierarchy(new File(directoryPathName))
+  }
+  /**
+    * recursively delete all directories in a relative path
+    * DO NOT DELETE absolute paths
+    *
+    * @param file: a directory hierarchy to delete
+    */
+  def deleteDirectoryHierarchy(file: File, atTop: Boolean = true): Boolean = {
+    if(file.getPath.split("/").last.isEmpty ||
+      file.getAbsolutePath == "/" ||
+      file.getPath.startsWith("/")) {
+      Driver.dramaticError(s"delete directory ${file.getPath} will not delete absolute paths")
+      false
     }
     else {
-      val directory = new java.io.File(directoryPathName)
-      if(directory.isDirectory) {
-        directory.delete()
-        val directories = directoryPathName.split("/+").reverse.tail
-        if (directories.nonEmpty) {
-          deleteDirectoryHierarchy(directories.reverse.mkString("/"))
+      val result = {
+        if(file.isDirectory) {
+          file.listFiles().forall( f => deleteDirectoryHierarchy(f)) && file.delete()
+        }
+        else {
+          file.delete()
         }
       }
+      result
     }
   }
 }

--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -116,9 +116,11 @@ class BlackBoxSourceHelper extends firrtl.Transform {
         }
         state
     }
-    val writer = new PrintWriter(new File(targetDir, BlackBoxSourceHelper.FileListName))
-    writer.write(fileList.map { fileName => s"-v $fileName" }.mkString("\n"))
-    writer.close()
+    if(fileList.nonEmpty) {
+      val writer = new PrintWriter(new File(targetDir, BlackBoxSourceHelper.FileListName))
+      writer.write(fileList.map { fileName => s"-v $fileName" }.mkString("\n"))
+      writer.close()
+    }
 
     resultState
   }

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -49,7 +49,7 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         optionsManager.makeTargetDir() should be (true)
         dir = new java.io.File("a/b/c")
         dir.exists() should be (true)
-        FileUtils.deleteDirectoryHierarchy(commonOptions.targetDirName)
+        FileUtils.deleteDirectoryHierarchy("a") should be (true)
       }
     }
   }
@@ -171,6 +171,19 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
         file.exists() should be (true)
         file.delete()
       }
+    }
+  }
+
+  "Directory deleter is handy for cleaning up after tests" - {
+    "for example making a directory tree, and deleting it looks like" in {
+      FileUtils.makeDirectory("dog/fox/wolf")
+      val dir = new File("dog/fox/wolf")
+      dir.exists() should be (true)
+      dir.isDirectory should be (true)
+
+      FileUtils.deleteDirectoryHierarchy("wolf") should be (false)
+      FileUtils.deleteDirectoryHierarchy("dog") should be (true)
+      dir.exists() should be (false)
     }
   }
 }


### PR DESCRIPTION
moving backend compilation utilities inadvertently lost the addition of a the black box verilog file list.
This fixes, that as well, as a couple of implementation bugs that slipped in.  Motivated by chisel PR [Move Backend Compilation Utilities](https://github.com/ucb-bar/chisel3/pull/400)