### PR TITLE
Return a new circuit object after execution

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -122,7 +122,7 @@ class BlackBoxSourceHelper extends firrtl.Transform {
       writer.close()
     }
 
-    resultState
+    CircuitState(resultState.circuit, resultState.form)
   }
 }
 


### PR DESCRIPTION
This fixes an issue I was having with my ClockListAnnotations being duplicated.

h/t @azidar