### PR TITLE
Add support for Analog types in partial connect

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -269,6 +269,7 @@ object Utils extends LazyLogging {
       case (_: UIntType, _: UIntType) => if (flip1 == flip2) Seq((0, 0)) else Nil
       case (_: SIntType, _: SIntType) => if (flip1 == flip2) Seq((0, 0)) else Nil
       case (_: FixedType, _: FixedType) => if (flip1 == flip2) Seq((0, 0)) else Nil
+      case (_: AnalogType, _: AnalogType) => if (flip1 == flip2) Seq((0, 0)) else Nil
       case (t1x: BundleType, t2x: BundleType) =>
         def emptyMap = Map[String, (Type, Orientation, Int)]()
         val t1_fields = t1x.fields.foldLeft(emptyMap, 0) { case ((map, ilen), f1) =>

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -392,7 +392,7 @@ object CheckTypes extends Pass {
         case (_: UIntType, _: UIntType) => flip1 == flip2
         case (_: SIntType, _: SIntType) => flip1 == flip2
         case (_: FixedType, _: FixedType) => flip1 == flip2
-        case (_: AnalogType, _: AnalogType) => false
+        case (_: AnalogType, _: AnalogType) => true
         case (t1: BundleType, t2: BundleType) =>
           val t1_fields = (t1.fields foldLeft Map[String, (Type, Orientation)]())(
             (map, f1) => map + (f1.name -> (f1.tpe, f1.flip)))

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -229,6 +229,7 @@ object InferWidths extends Pass {
       case (t1: SIntType, t2: SIntType) => Seq(WGeq(t1.width, t2.width))
       case (ClockType, ClockType) => Nil
       case (FixedType(w1, p1), FixedType(w2, p2)) => Seq(WGeq(w1,w2), WGeq(p1,p2))
+      case (AnalogType(w1), AnalogType(w2)) => Seq(WGeq(w1,w2), WGeq(w2,w1))
       case (t1: BundleType, t2: BundleType) =>
         (t1.fields zip t2.fields foldLeft Seq[WGeq]()){case (res, (f1, f2)) =>
           res ++ (f1.flip match {

--- a/src/main/scala/firrtl/passes/Passes.scala
+++ b/src/main/scala/firrtl/passes/Passes.scala
@@ -140,12 +140,17 @@ object ExpandConnects extends Pass {
             val ls = get_valid_points(sx.loc.tpe, sx.expr.tpe, Default, Default)
             val locs = create_exps(sx.loc)
             val exps = create_exps(sx.expr)
-            Block(ls map {case (x, y) =>
-              get_flip(sx.loc.tpe, x, Default) match {
-                 case Default => Connect(sx.info, locs(x), exps(y))
-                 case Flip => Connect(sx.info, exps(y), locs(x))
+            val stmts = ls map { case (x, y) =>
+              locs(x).tpe match {
+                case AnalogType(_) => Attach(sx.info, Seq(locs(x), exps(y)))
+                case _ =>
+                  get_flip(sx.loc.tpe, x, Default) match {
+                    case Default => Connect(sx.info, locs(x), exps(y))
+                    case Flip => Connect(sx.info, exps(y), locs(x))
+                  }
               }
-            })
+            }
+            Block(stmts)
           case sx => sx map expand_s
         }
       }

--- a/src/test/scala/firrtlTests/AttachSpec.scala
+++ b/src/test/scala/firrtlTests/AttachSpec.scala
@@ -144,6 +144,29 @@ class InoutVerilogSpec extends FirrtlFlatSpec {
     executeTest(input, check, compiler)
   }
 
+  it should "work in partial connect" in {
+    val compiler = new VerilogCompiler
+    val input =
+      """circuit Attaching :
+         |  module Attaching :
+         |    input foo : { b : UInt<3>, a : Analog<3> }
+         |    output bar : { b : UInt<3>, a : Analog<3> }
+         |    bar <- foo""".stripMargin
+    // Omitting `ifdef SYNTHESIS and `elseif verilator since it's tested above
+    val check =
+      """module Attaching(
+        |  input  [2:0] foo_b,
+        |  inout  [2:0] foo_a,
+        |  output  [2:0] bar_b,
+        |  inout  [2:0] bar_a
+        |);
+        |  assign bar_b = foo_b;
+        |  alias bar_a = foo_a;
+        |endmodule
+        |""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
+  }
+
   it should "preserve attach order" in {
     val compiler = new VerilogCompiler
     val input =
@@ -189,6 +212,31 @@ class InoutVerilogSpec extends FirrtlFlatSpec {
         |endmodule
         |""".stripMargin.split("\n") map normalized
     executeTest(input2, check2, compiler)
+  }
+
+  it should "infer widths" in {
+    val compiler = new VerilogCompiler
+    val input =
+     """circuit Attaching :
+        |  module Attaching :
+        |    input an: Analog
+        |    inst a of A
+        |    attach (an, a.an1)
+        |  module A:
+        |    input an1: Analog<3>""".stripMargin
+    val check =
+     """module Attaching(
+       |  inout  [2:0] an
+       |);
+       |  A a (
+       |    .an1(an)
+       |  );
+       |endmodule
+       |module A(
+       |  inout  [2:0] an1
+       |);
+       |endmodule""".stripMargin.split("\n") map normalized
+    executeTest(input, check, compiler)
   }
 }
 


### PR DESCRIPTION
I have the checks still check that the flips are the same despite Analog being bidirectional, thoughts?

This will allow bulk connecting of Analog types in the compatibility wrapper. One consequence is that I believe it will bypass the current Chisel restriction that you can only bulk connect Analog types once per module to prevent strange consequences of last connect semantics.