### PR TITLE
Emit memories larger than 512 MB with a sparse annotation

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -454,7 +454,11 @@ class VerilogEmitter extends Emitter with PassBased {
           instdeclares += Seq(");")
           sx
         case sx: DefMemory =>
-          declare("reg", sx.name, VectorType(sx.dataType, sx.depth))
+          val fullSize = sx.depth*(sx.dataType match { case GroundType(i:IntWidth) => i.width })
+          if(fullSize > (1 << 29))
+            declare("reg /* sparse */", sx.name, VectorType(sx.dataType, sx.depth))
+          else
+            declare("reg", sx.name, VectorType(sx.dataType, sx.depth))
           initialize_mem(sx)
           if (sx.readLatency != 0 || sx.writeLatency != 1)
             throw EmitterException("All memories should be transformed into " +

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -454,11 +454,9 @@ class VerilogEmitter extends Emitter with PassBased {
           instdeclares += Seq(");")
           sx
         case sx: DefMemory =>
-          val fullSize = sx.depth*(sx.dataType match { case GroundType(i:IntWidth) => i.width })
-          if(fullSize > (1 << 29))
-            declare("reg /* sparse */", sx.name, VectorType(sx.dataType, sx.depth))
-          else
-            declare("reg", sx.name, VectorType(sx.dataType, sx.depth))
+          val fullSize = sx.depth * (sx.dataType match { case GroundType(IntWidth(width)) => i.width })
+          val decl = if (fullSize > (1 << 29)) "reg /* sparse */" else "reg"
+          declare(decl, sx.name, VectorType(sx.dataType, sx.depth))
           initialize_mem(sx)
           if (sx.readLatency != 0 || sx.writeLatency != 1)
             throw EmitterException("All memories should be transformed into " +

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -454,7 +454,7 @@ class VerilogEmitter extends Emitter with PassBased {
           instdeclares += Seq(");")
           sx
         case sx: DefMemory =>
-          val fullSize = sx.depth * (sx.dataType match { case GroundType(IntWidth(width)) => i.width })
+          val fullSize = sx.depth * (sx.dataType match { case GroundType(IntWidth(width)) => width })
           val decl = if (fullSize > (1 << 29)) "reg /* sparse */" else "reg"
           declare(decl, sx.name, VectorType(sx.dataType, sx.depth))
           initialize_mem(sx)


### PR DESCRIPTION
This comment causes vcs to treat this as a spare memory,
so it will dynamically allocate the required memory, and can
support very large reg constructs this way. This is useful for
test bench memories that might be simulating back DRAM or the like.

I tested this on rocket-chip's TestRAM.