### PR TITLE
[skip chisel tests] Add ability to skip Chisel tests in Travis

### DIFF
--- a/.run_chisel_tests.sh
+++ b/.run_chisel_tests.sh
@@ -1,0 +1,11 @@
+set -e
+# Skip chisel tests if the commit message says to
+if [[ $TRAVIS_COMMIT_MESSAGE == *"[skip chisel tests]"* ]]; then
+  exit 0
+else
+  git clone https://github.com/ucb-bar/chisel3.git
+  mkdir -p chisel3/lib
+  cp utils/bin/firrtl.jar chisel3/lib
+  cd chisel3
+  sbt clean test
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
     PATH=$PATH:$VERILATOR_ROOT/bin:$TRAVIS_BUILD_DIR/utils/bin
 
 install:
-  # Grab Chisel 3
-  - git clone https://github.com/ucb-bar/chisel3.git
   # Install Verilator (if not found in cache)
   - bash .install_verilator.sh
 
@@ -30,8 +28,5 @@ script:
   - verilator --version
   - cd $TRAVIS_BUILD_DIR
   - sbt clean test assembly publish-local
-  - mkdir -p chisel3/lib
-  - cp utils/bin/firrtl.jar chisel3/lib
   # Chisel 3 Tests
-  - cd chisel3
-  - sbt clean test
+  - bash .run_chisel_tests.sh


### PR DESCRIPTION
Since #443 changes an API that chisel tests use, the Chisel tests can't pass. This PR adds a tag that we can use to skip the chisel tests. I could just [skip ci] but I want #443 to run the Firrtl tests so I thought this would be helpful