### PR TITLE
Fix warning from Cadence Incisive

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -527,7 +527,7 @@ class VerilogEmitter extends Emitter with PassBased {
         }
         emit(Seq(");"))
 
-        if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "always @(*) begin end"))
+        if (declares.isEmpty && assigns.isEmpty) emit(Seq(tab, "initial begin end"))
         for (x <- declares) emit(Seq(tab, x))
         for (x <- instdeclares) emit(Seq(tab, x))
         for (x <- assigns) emit(Seq(tab, x))


### PR DESCRIPTION
The fix for PR #305 caused a new compile warning from Cadence Incisive:

```
  always @(*) begin end
         |
ncelab: *W,STARMT (../TestHarness.MyConfig.v,196147|9): This @* expands to empty list, will never wake up.
```

This change satisfies all of: VCS, Incisive, Questa, Vivado, Verilator.