### PR TITLE
Add support for bundle fields to start with digits

### DIFF
--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -107,7 +107,7 @@ class ParserPropSpec extends FirrtlPropSpec {
     xs <- Gen.listOf(legalChar)
   } yield (x :: xs).mkString
 
-  property("Identifiers allow [A-Za-z0-9_$] but not allow starting with a digit or $") {
+  property("Identifiers should allow [A-Za-z0-9_$] but not allow starting with a digit or $") {
     forAll (identifier) { id =>
       whenever(id.nonEmpty) {
         val input = s"""

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -4,6 +4,8 @@ package firrtlTests
 
 import org.scalatest._
 import firrtl._
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
 
 class ParserSpec extends FirrtlFlatSpec {
 
@@ -29,14 +31,11 @@ class ParserSpec extends FirrtlFlatSpec {
 
   private object KeywordTests {
     val prelude = Seq("circuit top :", "  module top :")
-    val keywords = Seq( "circuit", "module", "extmodule", "input", "output",
-      "UInt", "SInt", "flip", "Clock", "wire", "reg", "reset", "with", "mem",
-      "data-type", "depth", "read-latency", "write-latency",
-      "read-under-write", "reader", "writer", "readwriter", "inst", "of",
-      "node", "is", "invalid", "when", "else", "stop", "printf", "skip", "old",
-      "new", "undefined", "mux", "validif", "UBits", "SBits", "cmem", "smem",
-      "mport", "infer", "read", "write", "rdwr"
-    ) ++ PrimOps.listing
+    val keywords = Seq("circuit", "module", "extmodule", "parameter", "input", "output", "UInt",
+      "SInt", "Analog", "Fixed", "flip", "Clock", "wire", "reg", "reset", "with", "mem", "depth",
+      "reader", "writer", "readwriter", "inst", "of", "node", "is", "invalid", "when", "else",
+      "stop", "printf", "skip", "old", "new", "undefined", "mux", "validif", "cmem", "smem",
+      "mport", "infer", "read", "write", "rdwr") ++ PrimOps.listing
   }
 
   // ********** Memories **********
@@ -91,6 +90,50 @@ class ParserSpec extends FirrtlFlatSpec {
     keywords foreach { keyword =>
       firrtl.Parser.parse((prelude ++ Seq(s"      wire ${keyword} : UInt",
                                           s"      ${keyword} <= ${keyword}")))
+    }
+  }
+}
+
+class ParserPropSpec extends FirrtlPropSpec {
+  // Disable shrinking on error.
+  import org.scalacheck.Shrink
+  implicit val noShrinkString = Shrink[String](_ => Stream.empty)
+
+  def legalStartChar = Gen.frequency((1, '_'), (20, Gen.alphaChar))
+  def legalChar = Gen.frequency((1, Gen.numChar), (1, '$'), (10, legalStartChar))
+
+  def identifier = for {
+    x <- legalStartChar
+    xs <- Gen.listOf(legalChar)
+  } yield (x :: xs).mkString
+
+  property("Identifiers allow [A-Za-z0-9_$] but not allow starting with a digit or $") {
+    forAll (identifier) { id =>
+      whenever(id.nonEmpty) {
+        val input = s"""
+           |circuit Test :
+           |  module Test :
+           |    input $id : UInt<32>
+           |""".stripMargin
+        firrtl.Parser.parse(input split "\n")
+      }
+    }
+  }
+
+  def bundleField = for {
+    xs <- Gen.nonEmptyListOf(legalChar)
+  } yield xs.mkString
+
+  property("Bundle fields should allow [A-Za-z0-9_] including starting with a digit or $") {
+    forAll (identifier, bundleField) { case (id, field) =>
+      whenever(id.nonEmpty && field.nonEmpty) {
+        val input = s"""
+           |circuit Test :
+           |  module Test :
+           |    input $id : { $field : UInt<32> }
+           |""".stripMargin
+        firrtl.Parser.parse(input split "\n")
+      }
     }
   }
 }


### PR DESCRIPTION
Also remove parsing support for ids with characters not supported in
Verilog nor in the Firrtl spec

As discussed in https://github.com/ucb-bar/chisel3/pull/517, it is useful for Firrtl to support digits as legal identifiers in fields since chisel Records can be used as heterogeneous Vecs

Adding this support was more complicated than I expected since it involved refactoring the lexer rules a bit but here it is!

I also removed "support" for parsing ids that aren't actually supported