### PR TITLE
Fix digit parsing

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -164,6 +164,7 @@ exp
   | 'SInt' ('<' intLit '>')? '(' intLit ')'
   | id    // Ref
   | exp '.' fieldId
+  | exp '.' DoubleLit // TODO Workaround for #470
   | exp '[' intLit ']'
   | exp '[' exp ']'
   | 'mux(' exp exp exp ')'

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -300,7 +300,7 @@ HexLit
   ;
 
 DoubleLit
-  : ( '+' | '-' )? Digit+ '.' Digit+ ( 'E' Digit+ )?
+  : ( '+' | '-' )? Digit+ '.' Digit+ ( 'E' ( '+' | '-' )? Digit+ )?
   ;
 
 fragment

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -93,6 +93,19 @@ class ParserSpec extends FirrtlFlatSpec {
     }
   }
 
+  // ********** Digits as Fields **********
+  "Digits" should "be legal fields in bundles and in subexpressions" in {
+    val input = """
+      |circuit Test :
+      |  module Test :
+      |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
+      |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
+      |    in.0.1 <= in.0.0
+      |    in2.4.23.bar.123 <= in2.4.23.foo
+      """.stripMargin
+    firrtl.Parser.parse(input split "\n")
+  }
+
   // ********** Doubles as parameters **********
   "Doubles" should "be legal parameters for extmodules" in {
     val nums = Seq("1.0", "7.6", "3.00004", "1.0E10", "1.0023E-17")

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -92,6 +92,29 @@ class ParserSpec extends FirrtlFlatSpec {
                                           s"      ${keyword} <= ${keyword}")))
     }
   }
+
+  // ********** Doubles as parameters **********
+  "Doubles" should "be legal parameters for extmodules" in {
+    val nums = Seq("1.0", "7.6", "3.00004", "1.0E10", "1.0023E-17")
+    val signs = Seq("", "+", "-")
+    val tests = "0.0" +: (signs flatMap (s => nums map (n => s + n)))
+    for (test <- tests) {
+      println(s"Trying $test")
+      val input = s"""
+        |circuit Test :
+        |  extmodule Ext :
+        |    input foo : UInt<32>
+        |
+        |    defname = MyExtModule
+        |    parameter REAL = $test
+        |
+        |  module Test :
+        |    input foo : UInt<32>
+        |    output bar : UInt<32>
+        """.stripMargin
+      firrtl.Parser.parse(input split "\n")
+    }
+  }
 }
 
 class ParserPropSpec extends FirrtlPropSpec {


### PR DESCRIPTION
In trying to fix #470, I tried to convert DoubleLit to a parser rule instead of a lexer rule (to allow backtracking), but it's a much more subtle issue (thus the addition of DoubleLit parsing tests). #470 is blocking rocket-chip (https://travis-ci.org/ucb-bar/rocket-chip/builds/206055725) so this is a workaround to keep things moving forward, we should discuss a better solution but I think this PR is fine, just inelegant.