### PR TITLE
Eliminate useless ports

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -748,7 +748,8 @@ class VerilogEmitter extends Transform with PassBased with Emitter {
     passes.VerilogModulusCleanup,
     passes.VerilogWrap,
     passes.VerilogRename,
-    passes.VerilogPrep)
+    passes.VerilogPrep,
+    passes.DeadCodeElimination)
 
   def emit(state: CircuitState, writer: Writer): Unit = {
     writer.write(preamble)

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -749,7 +749,8 @@ class VerilogEmitter extends Transform with PassBased with Emitter {
     passes.VerilogWrap,
     passes.VerilogRename,
     passes.VerilogPrep,
-    passes.DeadCodeElimination)
+    passes.DeadCodeElimination,
+    passes.UnusedPortElimination)
 
   def emit(state: CircuitState, writer: Writer): Unit = {
     writer.write(preamble)

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -105,8 +105,7 @@ class LowFirrtlOptimization extends CoreTransform {
     passes.memlib.VerilogMemDelays, // TODO move to Verilog emitter
     passes.ConstProp,
     passes.SplitExpressions,
-    passes.CommonSubexpressionElimination,
-    passes.DeadCodeElimination)
+    passes.CommonSubexpressionElimination)
 }
 
 

--- a/src/main/scala/firrtl/passes/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/passes/DeadCodeElimination.scala
@@ -12,8 +12,8 @@ import annotation.tailrec
 object DeadCodeElimination extends Pass {
   def name = "Dead Code Elimination"
 
-  private def dceOnce(s: Statement): (Statement, Long) = {
-    val referenced = collection.mutable.HashSet[String]()
+  private def dceOnce(ports: Seq[Port], s: Statement): (Statement, Long) = {
+    val referenced = collection.mutable.HashSet[String](ports.map(_.name):_*)
     var nEliminated = 0L
 
     def checkExpressionUse(e: Expression): Expression = {
@@ -24,7 +24,15 @@ object DeadCodeElimination extends Pass {
       e
     }
 
-    def checkUse(s: Statement): Statement = s map checkUse map checkExpressionUse
+    def checkUse(s: Statement): Statement = {
+      val out = s match {
+        case x: Connect => x.copy(expr = checkExpressionUse(x.expr))
+        case x: PartialConnect => x.copy(expr = checkExpressionUse(x.expr))
+        case x: IsInvalid => x
+        case _ => s map checkUse map checkExpressionUse
+      }
+      out
+    }
 
     def maybeEliminate(x: Statement, name: String) =
       if (referenced(name)) x
@@ -33,10 +41,18 @@ object DeadCodeElimination extends Pass {
         EmptyStmt
       }
 
+    def maybeEliminateExp(s: Statement, expr: Expression) = expr match {
+      case x: WRef => maybeEliminate(s, x.name)
+      case _ => s
+    }
+
     def removeUnused(s: Statement): Statement = s match {
       case x: DefRegister => maybeEliminate(x, x.name)
       case x: DefWire => maybeEliminate(x, x.name)
       case x: DefNode => maybeEliminate(x, x.name)
+      case x: Connect => maybeEliminateExp(x, x.loc)
+      case x: PartialConnect => maybeEliminateExp(x, x.loc)
+      case x: IsInvalid => maybeEliminateExp(x, x.expr)
       case x => s map removeUnused
     }
 
@@ -45,15 +61,15 @@ object DeadCodeElimination extends Pass {
   }
 
   @tailrec
-  private def dce(s: Statement): Statement = {
-    val (res, n) = dceOnce(s)
-    if (n > 0) dce(res) else res
+  private def dce(ports: Seq[Port], s: Statement): Statement = {
+    val (res, n) = dceOnce(ports, s)
+    if (n > 0) dce(ports, res) else res
   }
 
   def run(c: Circuit): Circuit = {
     val modulesx = c.modules.map {
       case m: ExtModule => m
-      case m: Module => Module(m.info, m.name, m.ports, dce(m.body))
+      case m: Module => Module(m.info, m.name, m.ports, dce(m.ports, m.body))
     }
     Circuit(c.info, modulesx, c.main)
   }

--- a/src/main/scala/firrtl/passes/UnusedPortElimination.scala
+++ b/src/main/scala/firrtl/passes/UnusedPortElimination.scala
@@ -1,0 +1,102 @@
+// See LICENSE for license details.
+
+package firrtl.passes
+
+import firrtl._
+import firrtl.ir._
+import firrtl.Utils._
+import firrtl.Mappers._
+import collection.mutable.{HashSet, HashMap}
+
+import annotation.tailrec
+
+object UnusedPortElimination extends Pass {
+  def name = "Unused Port Elimination"
+
+  private def usefulPorts(s: Statement): HashSet[String] = {
+    val referenced = HashSet[String]()
+    var invalid = List[String]()
+    var binding = List[(String, String)]()
+
+    def checkExpressionUse(e: Expression): Expression = {
+      e match {
+        case WRef(name, _, _, _) => referenced += name
+        case _ => e map checkExpressionUse
+      }
+      e
+    }
+
+    def checkUse(s: Statement): Statement = {
+      s match {
+        case IsInvalid(_, x: WRef) => invalid = x.name :: invalid
+        case Connect(_, loc: WRef, expr: WRef) => binding = ((loc.name, expr.name)) :: binding
+        case PartialConnect(_, loc: WRef, expr: WRef) => binding = ((loc.name, expr.name)) :: binding
+        case _ => Unit
+      }
+      s map checkUse map checkExpressionUse
+    }
+
+    checkUse(s)
+
+    // DFS
+    val edges = binding.groupBy(_._2).mapValues(_.map(_._1))
+    var seen = HashSet[String]()
+    while (!invalid.isEmpty) {
+      val head = invalid.head
+      invalid = invalid.tail
+      if (!seen.contains(head)) {
+        seen += head
+        invalid = edges.getOrElse(head, Nil) ++ invalid
+      }
+    }
+
+    referenced -- seen
+  }
+
+  private def remove_root(ex: Expression): Expression = ex match {
+    case ex: WSubField => ex.exp match {
+      case (e: WSubField) => remove_root(e)
+      case (_: WRef) => WRef(ex.name, ex.tpe, InstanceKind, UNKNOWNGENDER)
+    }
+    case _ => error("Shouldn't be here")
+  }
+
+  private def cutPorts(killed: HashMap[(String, String), Direction])(s: Statement): Statement = s match {
+    case i: WDefInstanceConnector => {
+      def obj(p: Expression) = (i.module, LowerTypes.loweredName(remove_root(p)))
+      val (kill, keep) = i.portCons.partition { case (p, _) => killed.contains(obj(p)) }
+      val invalids = kill.map { case (p, x) =>
+        killed(obj(p)) match {
+          case Input => EmptyStmt
+          case Output => IsInvalid(i.info, x)
+      } }
+      Block(invalids :+ i.copy(portCons = keep))
+    }
+    case _ => s map cutPorts(killed)
+  }
+
+  @tailrec
+  def run(c: Circuit): Circuit = {
+    val killed = HashMap[(String, String), Direction]()
+
+    // Remove unused ports
+    val modulesx = c.modules.map {
+      case m: ExtModule => m
+      case m: Module => {
+        val useful = usefulPorts(m.body)
+        val (keep, kill) = m.ports partition { x => useful.contains(x.name) }
+        kill.foreach { case p: Port => killed += ((m.name, p.name) -> p.direction) }
+        Module(m.info, m.name, keep, m.body)
+      }
+    }
+
+    // Remove references to unused ports
+    val modulesy = modulesx.map {
+      case m: ExtModule => m
+      case m: Module => { Module(m.info, m.name, m.ports, cutPorts(killed)(m.body)) }
+    }
+
+    val out = Circuit(c.info, modulesy, c.main)
+    if (killed.isEmpty) out else run(DeadCodeElimination.run(out))
+  }
+}


### PR DESCRIPTION
This adds a pass which prunes disconnected input and output ports. These were causing us problems with achieving coverage.

Please pay special attention and review the DeadCodeElimination changes. This PR makes the dead code elimination significantly more aggressive, which may have corner cases I didn't exercise in Rocket.