### PR TITLE
Add TargetDirAnnotation to give transforms access

### DIFF
--- a/src/main/scala/firrtl/Driver.scala
+++ b/src/main/scala/firrtl/Driver.scala
@@ -164,8 +164,13 @@ object Driver {
     // Output Annotations
     val outputAnnos = firrtlConfig.getEmitterAnnos(optionsManager)
 
+    // Should these and outputAnnos be moved to loadAnnotations?
+    val globalAnnos = Seq(TargetDirAnnotation(optionsManager.targetDirName))
+
     val finalState = firrtlConfig.compiler.compile(
-      CircuitState(parsedInput, ChirrtlForm, Some(AnnotationMap(firrtlConfig.annotations ++ outputAnnos))),
+      CircuitState(parsedInput,
+                   ChirrtlForm,
+                   Some(AnnotationMap(firrtlConfig.annotations ++ outputAnnos ++ globalAnnos))),
       firrtlConfig.customTransforms
     )
 

--- a/src/main/scala/firrtl/ExecutionOptionsManager.scala
+++ b/src/main/scala/firrtl/ExecutionOptionsManager.scala
@@ -46,6 +46,9 @@ case class CommonOptions(
   }
 }
 
+/** [[annotations.GlobalCircuitAnnotation]] that contains the [[CommonOptions]] target directory */
+object TargetDirAnnotation extends GlobalCircuitAnnotation
+
 trait HasCommonOptions {
   self: ExecutionOptionsManager =>
   var commonOptions = CommonOptions()

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -41,3 +41,20 @@ object DeletedAnnotation {
     case _ => None
   }
 }
+
+/** Parent class to create global annotations
+  *
+  * These annotations are Circuit-level and available to every transform
+  */
+abstract class GlobalCircuitAnnotation {
+  private lazy val marker = this.getClass.getName
+  def apply(value: String): Annotation =
+    Annotation(CircuitTopName, classOf[Transform], s"$marker:$value")
+  def unapply(a: Annotation): Option[String] = a match {
+    // Assumes transform is already filtered appropriately
+    case Annotation(CircuitTopName, _, str) if str.startsWith(marker) =>
+      Some(str.stripPrefix(s"$marker:"))
+    case _ => None
+  }
+}
+

--- a/src/test/scala/firrtlTests/annotationTests/TargetDirAnnotationSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/TargetDirAnnotationSpec.scala
@@ -1,0 +1,71 @@
+// See LICENSE for license details.
+
+package firrtlTests
+package annotationTests
+
+import firrtlTests._
+import firrtl._
+
+/** Looks for [[TargetDirAnnotation]] */
+class FindTargetDirTransform(expected: String) extends Transform {
+  def inputForm = HighForm
+  def outputForm = HighForm
+  var foundTargetDir = false
+  var run = false
+  def execute(state: CircuitState): CircuitState = {
+    run = true
+    state.annotations.foreach { aMap =>
+      aMap.annotations.collectFirst {
+        case TargetDirAnnotation(expected) =>
+          foundTargetDir = true
+      }
+    }
+    state
+  }
+}
+
+class TargetDirAnnotationSpec extends FirrtlFlatSpec {
+  behavior of "The target directory"
+
+  val input =
+    """circuit Top :
+      |  module Top :
+      |    input foo : UInt<32>
+      |    output bar : UInt<32>
+      |    bar <= foo
+      """.stripMargin
+  val targetDir = "a/b/c"
+
+  it should "be available as an annotation when using execution options" in {
+    val findTargetDir = new FindTargetDirTransform(targetDir) // looks for the annotation
+
+    val optionsManager = new ExecutionOptionsManager("TargetDir") with HasFirrtlOptions {
+      commonOptions = commonOptions.copy(targetDirName = targetDir,
+                                         topName = "Top")
+      firrtlOptions = firrtlOptions.copy(compilerName = "high",
+                                         firrtlSource = Some(input),
+                                         customTransforms = Seq(findTargetDir))
+    }
+    Driver.execute(optionsManager)
+
+    // Check that FindTargetDirTransform transform is run and finds the annotation
+    findTargetDir.run should be (true)
+    findTargetDir.foundTargetDir should be (true)
+
+    // Delete created directory
+    val dir = new java.io.File(targetDir)
+    dir.exists should be (true)
+    FileUtils.deleteDirectoryHierarchy("a") should be (true)
+  }
+
+  it should "NOT be available as an annotation when using a raw compiler" in {
+    val findTargetDir = new FindTargetDirTransform(targetDir) // looks for the annotation
+    val compiler = new VerilogCompiler
+    val circuit = Parser.parse(input split "\n")
+    compiler.compileAndEmit(CircuitState(circuit, HighForm), Seq(findTargetDir))
+
+    // Check that FindTargetDirTransform does not find the annotation
+    findTargetDir.run should be (true)
+    findTargetDir.foundTargetDir should be (false)
+  }
+}


### PR DESCRIPTION
Also add GlobalCircuitAnnotation for creating similar annotations

* Thoughts about the "GlobalCircuitAnnotation" API? It's just a helper for annotations that are globally available and hold a single String. 
* Given the concept of "global annotations" or even annotations that may target a superclass transform, should `getMyAnnotations` return these? Or should `getMyAnnotations` continue to just return ones that target a given transform directly? We could add a new function like `getGlobalAnnotations` for ones that target `Transform` itself.
* Note that `Driver.execute` adds the annotation. Think the implementation is okay? Some annotations like this only make sense in the context of using execution options, which means we're going to be shifting people toward using them. As we had discussed @azidar, if we want to do any cleanup here it's only going to become higher priority.