### PR TITLE
Fix bug where zero width expressions in nodes wouldn't get zeroed

### DIFF
--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -49,7 +49,7 @@ object ZeroWidth extends Pass {
     }
     case DefNode(info, name, value) => removeZero(value.tpe) match {
       case None => EmptyStmt
-      case Some(t) => s
+      case Some(t) => DefNode(info, name, onExp(value))
     }
     case sx => sx map onStmt
   }

--- a/src/test/scala/firrtlTests/ZeroWidthTests.scala
+++ b/src/test/scala/firrtlTests/ZeroWidthTests.scala
@@ -105,6 +105,20 @@ class ZeroWidthTests extends FirrtlFlatSpec {
         |    skip""".stripMargin
       (parse(exec(input)).serialize) should be (parse(check).serialize)
   }
+  "Expression in node with type <0>" should "be replaced by UInt<1>(0)" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x: UInt<1>
+        |    input y: UInt<0>
+        |    node z = add(x, y)""".stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input x: UInt<1>
+        |    node z = add(x, UInt<1>(0))""".stripMargin
+      (parse(exec(input)).serialize) should be (parse(check).serialize)
+  }
 }
 
 class ZeroWidthVerilog extends FirrtlFlatSpec {


### PR DESCRIPTION
Fixes problem in https://github.com/ucb-bar/rocket-chip/pull/626 and https://github.com/ucb-bar/firrtl/pull/478