### PR TITLE
Find a single cycle from potentially many in a combinational SCC

### DIFF
--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -300,7 +300,21 @@ class DiGraph[T] (val edges: Map[T, Set[T]]) extends DiGraphLike[T] {
   }
 
   /** Return a graph with only a subset of the nodes
+    *
+    * Any edge including a deleted node will be deleted
     * 
+    * @param vprime the Set[T] of desired vertices
+    * @throws IllegalArgumentException if vprime is not a subset of V
+    * @return the subgraph
+    */
+  def subgraph(vprime: Set[T]): DiGraph[T] = {
+    require(vprime.subsetOf(edges.keySet))
+    val eprime = vprime.map(v => (v,getEdges(v) & vprime)).toMap
+    new DiGraph(eprime)
+  }
+
+  /** Return a graph with only a subset of the nodes
+    *
     * Any path between two non-deleted nodes (u,v) that traverses only
     * deleted nodes will be transformed into an edge (u,v).
     * 
@@ -310,7 +324,7 @@ class DiGraph[T] (val edges: Map[T, Set[T]]) extends DiGraphLike[T] {
     */
   def simplify(vprime: Set[T]): DiGraph[T] = {
     require(vprime.subsetOf(edges.keySet))
-    val eprime = vprime.map( v => (v,reachableFrom(v) & vprime) ).toMap
+    val eprime = vprime.map( v => (v,reachableFrom(v) & (vprime-v)) ).toMap
     new DiGraph(eprime)
   }
 

--- a/src/test/scala/firrtlTests/CheckCombLoopsSpec.scala
+++ b/src/test/scala/firrtlTests/CheckCombLoopsSpec.scala
@@ -123,5 +123,28 @@ class CheckCombLoopsSpec extends SimpleTransformSpec {
     }
   }
 
+  "Multiple simple loops in one SCC" should "throw an exception" in {
+    val input = """circuit hasloops :
+                   |  module hasloops :
+                   |    input i : UInt<1>
+                   |    output o : UInt<1>
+                   |    wire a : UInt<1>
+                   |    wire b : UInt<1>
+                   |    wire c : UInt<1>
+                   |    wire d : UInt<1>
+                   |    wire e : UInt<1>
+                   |    a <= and(c,i)
+                   |    b <= and(a,d)
+                   |    c <= b
+                   |    d <= and(c,e)
+                   |    e <= b
+                   |    o <= e
+                   |""".stripMargin
+
+    val writer = new java.io.StringWriter
+    intercept[CheckCombLoops.CombLoopException] {
+      compile(CircuitState(parse(input), ChirrtlForm, None), writer)
+    }
+  }
 
 }


### PR DESCRIPTION
This addresses #517 

The underlying issue is that an SCC may contain _multiple_ loops (that sometimes never form a single simple cycle), in which case the SCC algorithm will return them in an order that may not be traversable as a single path. Since the combinational loop detection pass does a lot of post-processing to pretty-print the loops, the loop-reporting steps failed under these conditions.

An extra step was added to extract a single simple cycle to report in the exception.