### PR TITLE
DecorateMems should not delete annoations

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
+++ b/src/main/scala/firrtl/passes/memlib/DecorateMems.scala
@@ -16,7 +16,8 @@ class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform 
       import CustomYAMLProtocol._
       val configs = r.parse[Config]
       val cN = CircuitName(state.circuit.main)
-      val (as, pins) = configs.foldLeft((Seq.empty[Annotation], Seq.empty[String])) { case ((annos, pins), config) =>
+      val oldAnnos = state.annotations.getOrElse(AnnotationMap(Seq.empty)).annotations
+      val (as, pins) = configs.foldLeft((oldAnnos, Seq.empty[String])) { case ((annos, pins), config) =>
         val top = TopAnnotation(ModuleName(config.top.name, cN), config.pin.name)
         val source = SourceAnnotation(ComponentName(config.source.name, ModuleName(config.source.module, cN)), config.pin.name)
         (annos ++ Seq(top, source), pins :+ config.pin.name)


### PR DESCRIPTION
Fixes my issue with ucb-bar/barstools#18 and #519 

Must have just been missed when the annotations api changed 