### PR TITLE
Add checks on register clock and reset types (#33)

### DIFF
--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -92,6 +92,12 @@ object CheckWidths extends Pass {
               errors.append(new AttachWidthsNotEqual(infox, mname, e.serialize, exprs.head.serialize))
           )
           s
+        case sx: DefRegister =>
+          sx.reset.tpe match {
+            case UIntType(IntWidth(w)) if w == 1 =>
+            case _ => errors.append(new CheckTypes.IllegalResetType(info, mname, sx.name))
+          }
+          s
         case _ => s
       }
     }


### PR DESCRIPTION
This fixes #33 

One issue is that CheckTypes can run before InferWidths, so _theoretically_ it's possible that the reset could be of unknown width. Therefore, this check ensures that the reset signal has `UIntType` type with either unknown or one-bit width.

I also added tests for both checks.