### PR TITLE
Fix performance bug in ZeroWidth

### DIFF
--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -40,15 +40,10 @@ object ZeroWidth extends Transform {
     case VectorType(t, size) => removeZero(t) map (VectorType(_, size))
     case x => Some(x)
   }
-  private def onExp(e: Expression): Expression = removeZero(e.tpe) match {
-    case None => e.tpe match {
-      case UIntType(x) => UIntLiteral(ZERO, IntWidth(BigInt(1)))
-      case SIntType(x) => SIntLiteral(ZERO, IntWidth(BigInt(1)))
-      case _ => throwInternalError
-    }
-    case Some(t) => 
-      def replaceType(x: Type): Type = t
-      (e map replaceType) map onExp
+  private def onExp(e: Expression): Expression = e.tpe match {
+    case UIntType(IntWidth(ZERO)) => UIntLiteral(ZERO, IntWidth(BigInt(1)))
+    case SIntType(IntWidth(ZERO)) => SIntLiteral(ZERO, IntWidth(BigInt(1)))
+    case other => e map onExp
   }
   private def onStmt(renames: RenameMap)(s: Statement): Statement = s match {
     case (_: DefWire| _: DefRegister| _: DefMemory) =>


### PR DESCRIPTION
We were recursing on Types of Expressions which not only is super inefficient
(especially since we are already calling InferTypes afterward), but also
duplicates each of the Type objects that need changing.

This also means default BOOM configs can be run through firrtl without having to increase the default amount of memory given to sbt.