### PR TITLE
Improvements to Verilog Randomization Emission

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -400,12 +400,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
         assigns += Seq("assign ", e, " = ", syn, ";")
         assigns += Seq("`else")
         assigns += Seq("assign ", e, " = ", garbageCond, " ? ", rand_string(syn.tpe), " : ", syn, ";")
-        assigns += Seq("`endif")
+        assigns += Seq("`endif // RANDOMIZE_GARBAGE_ASSIGN")
       }
       def invalidAssign(e: Expression) = {
         assigns += Seq("`ifdef RANDOMIZE_INVALID_ASSIGN")
         assigns += Seq("assign ", e, " = ", rand_string(e.tpe), ";")
-        assigns += Seq("`endif")
+        assigns += Seq("`endif // RANDOMIZE_INVALID_ASSIGN")
       }
       def update_and_reset(r: Expression, clk: Expression, reset: Expression, init: Expression) = {
         // We want to flatten Mux trees for reg updates into if-trees for
@@ -480,7 +480,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       def initialize(e: Expression) = {
         initials += Seq("`ifdef RANDOMIZE_REG_INIT")
         initials += Seq(e, " = ", rand_string(e.tpe), ";")
-        initials += Seq("`endif")
+        initials += Seq("`endif // RANDOMIZE_REG_INIT")
       }
 
       def initialize_mem(s: DefMemory) {
@@ -490,7 +490,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
         initials += Seq("for (initvar = 0; initvar < ", s.depth, "; initvar = initvar+1)")
         initials += Seq(tab, WSubAccess(wref(s.name, s.dataType), index, s.dataType, FEMALE),
                              " = ", rstring,";")
-        initials += Seq("`endif")
+        initials += Seq("`endif // RANDOMIZE_MEM_INIT")
       }
 
       def simulate(clk: Expression, en: Expression, s: Seq[Any], cond: Option[String]) {
@@ -509,7 +509,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           at_clock(clk) += Seq(tab,"end")
           at_clock(clk) += Seq("`endif")
         }
-        at_clock(clk) += Seq("`endif")
+        at_clock(clk) += Seq("`endif // SYNTHESIS")
       }
 
       def stop(ret: Int): Seq[Any] = Seq(if (ret == 0) "$finish;" else "$fatal;")
@@ -708,7 +708,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
           emit(Seq("    `endif"))
           for (x <- initials) emit(Seq(tab, x))
           emit(Seq("  end"))
-          emit(Seq("`endif"))
+          emit(Seq("`endif // RANDOMIZE"))
         }
  
         for (clk_stream <- at_clock if clk_stream._2.nonEmpty) {

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -357,6 +357,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       val netlist = mutable.LinkedHashMap[WrappedExpression, Expression]()
       val addrRegs = mutable.HashSet[WrappedExpression]()
       val namespace = Namespace(m)
+      namespace.newName("_RAND") // Start rand names at _RAND_0
       def build_netlist(s: Statement): Statement = s map build_netlist match {
         case sx: Connect =>
           netlist(sx.loc) = sx.expr
@@ -469,7 +470,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       // Declares an intermediate wire to hold a large enough random number.
       // Then, return the correct number of bits selected from the random value
       def rand_string(t: Type) : Seq[Any] = {
-         val nx = namespace.newTemp
+         val nx = namespace.newName("_RAND")
          val rand = VRandom(bitWidth(t))
          val tx = SIntType(IntWidth(rand.realWidth))
          declare("reg",nx, tx)


### PR DESCRIPTION
1. Add some comments to `endif
    Makes Verilog more readable to both humans and scripts
1. Change base of randomization values to _RAND instead of _GEN