### PR TITLE
Display the total time firrtl took to compile

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -420,7 +420,7 @@ trait Compiler extends LazyLogging {
       allTransforms.foldLeft(state) { (in, xform) => xform.runTransform(in) }
     }
 
-    logger.info(f"Total FIRRTL Compile Time: $timeMillis%.1f ms")
+    logger.error(f"Total FIRRTL Compile Time: $timeMillis%.1f ms")
 
     finalState
   }

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -416,7 +416,12 @@ trait Compiler extends LazyLogging {
   def compile(state: CircuitState, customTransforms: Seq[Transform]): CircuitState = {
     val allTransforms = CompilerUtils.mergeTransforms(transforms, customTransforms) :+ emitter
 
-    val finalState = allTransforms.foldLeft(state) { (in, xform) => xform.runTransform(in) }
+    val (timeMillis, finalState) = Utils.time {
+      allTransforms.foldLeft(state) { (in, xform) => xform.runTransform(in) }
+    }
+
+    logger.info(f"Total FIRRTL Compile Time: $timeMillis%.1f ms")
+
     finalState
   }
 


### PR DESCRIPTION
I find it nice that chisel prints this info out.

Ideally I'd also like to print this out at a different log level so we can just get total compile time without getting individual pass timings. Open to opinions on how/whether to do that.